### PR TITLE
Disable nightly test runs

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -6,9 +6,10 @@ on:
   push:
     branches:
     - master
-  schedule:
-    # Three-hours after midnight Pacific
-    - cron: "0 11 * * *"
+# Skip nightly runs, at least until the org's GitHub Actions budget problem is resolved.
+#   schedule:
+#     # Three-hours after midnight Pacific
+#     - cron: "0 11 * * *"
 
 jobs:
 


### PR DESCRIPTION
Skip nightly runs, at least until the org's GitHub Actions budget problem is resolved.

Perhaps we don't need to be running these nightlies anyway, as testing changes in branches and on push to master will ensure this Provider's correctness without ongoing daily consumption of GitHub Actions minutes.