### PR TITLE
Add netrc support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,8 @@ machine api.heroku.com
 ...
 ```
 
+The directory containing the `.netrc` file can be overridden by the `NETRC` environment variable as described [here](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html).
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -164,13 +164,18 @@ func (c *Config) applyNetrcFile() error {
 	path := os.Getenv("NETRC_PATH")
 
 	if path == "" {
+		dir := os.Getenv("NETRC")
+		if dir == "" {
+			dir = "~"
+		}
+
 		filename := ".netrc"
 		if runtime.GOOS == "windows" {
 			filename = "_netrc"
 		}
 
 		var err error
-		path, err = homedir.Expand("~/" + filename)
+		path, err = homedir.Expand(fmt.Sprintf("%s/", dir) + filename)
 		if err != nil {
 			return err
 		}

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/bgentry/go-netrc/netrc"
@@ -175,7 +176,7 @@ func (c *Config) applyNetrcFile() error {
 		}
 
 		var err error
-		path, err = homedir.Expand(fmt.Sprintf("%s/", dir) + filename)
+		path, err = homedir.Expand(filepath.Join(dir, filename))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Context

According to [GNU netrc documentation](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html#:~:text=netrc%20file-,The%20.,the%20command%20line%20option%20%2DN%20.), the `NETRC` environment variable can be used to specify a directory containing a `.netrc` file:

> The .netrc file contains login and initialization information used by the auto-login process. It generally resides in the user’s home directory, but a location outside of the home directory can be set using the environment variable NETRC.

Currently, this terraform provider does not honour the NETRC environment variable.

## Solution

Allow value of the `NETRC` environment variable to take precedence over the default, "~".
