### PR TITLE
Update module refs to v3

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ test: fmtcheck
 		xargs -t -n4 go test -v $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/version.ProviderVersion=test"
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/v2/version.ProviderVersion=test"
 
 vet:
 	@echo "go vet ."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ test: fmtcheck
 		xargs -t -n4 go test -v $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/v2/version.ProviderVersion=test"
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/v3/version.ProviderVersion=test"
 
 vet:
 	@echo "go vet ."

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 With Go language, the repository must be cloned to a specific path in `$GOPATH/src` that matches its module import path.
 
 ```sh
-mkdir -p $GOPATH/src/github.com/terraform-providers
-cd $GOPATH/src/github.com/terraform-providers
+mkdir -p $GOPATH/src/github.com/heroku
+cd $GOPATH/src/github.com/heroku
 git clone git@github.com:heroku/terraform-provider-heroku
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/heroku/terraform-provider-heroku/v2
+module github.com/heroku/terraform-provider-heroku/v3
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/heroku/terraform-provider-heroku
+module github.com/heroku/terraform-provider-heroku/v2
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/version"
+	"github.com/heroku/terraform-provider-heroku/v2/version"
 	homedir "github.com/mitchellh/go-homedir"
 )
 

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v2/version"
+	"github.com/heroku/terraform-provider-heroku/v3/version"
 	homedir "github.com/mitchellh/go-homedir"
 )
 

--- a/heroku/helper.go
+++ b/heroku/helper.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v2/version"
+	"github.com/heroku/terraform-provider-heroku/v3/version"
 )
 
 // getAppName extracts the app attribute generically from a Heroku resource.

--- a/heroku/helper.go
+++ b/heroku/helper.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/version"
+	"github.com/heroku/terraform-provider-heroku/v2/version"
 )
 
 // getAppName extracts the app attribute generically from a Heroku resource.

--- a/heroku/provider_test.go
+++ b/heroku/provider_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	helper "github.com/heroku/terraform-provider-heroku/v2/helper/test"
+	helper "github.com/heroku/terraform-provider-heroku/v3/helper/test"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider

--- a/heroku/provider_test.go
+++ b/heroku/provider_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	helper "github.com/heroku/terraform-provider-heroku/helper/test"
+	helper "github.com/heroku/terraform-provider-heroku/v2/helper/test"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/heroku/terraform-provider-heroku/v2/heroku"
+	"github.com/heroku/terraform-provider-heroku/v3/heroku"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/heroku/terraform-provider-heroku/heroku"
+	"github.com/heroku/terraform-provider-heroku/v2/heroku"
 )
 
 func main() {

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ package version
 //https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/version
 //This takes advantage of a new build flag populating the binary version of the
 //provider, for example:
-//-ldflags="-X=github.com/heroku/terraform-provider-heroku/v2/version.ProviderVersion=x.x.x"
+//-ldflags="-X=github.com/heroku/terraform-provider-heroku/v3/version.ProviderVersion=x.x.x"
 
 var (
 	// ProviderVersion is set during the release process to the release version of the binary, and

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ package version
 //https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/version
 //This takes advantage of a new build flag populating the binary version of the
 //provider, for example:
-//-ldflags="-X=github.com/heroku/terraform-provider-heroku/version.ProviderVersion=x.x.x"
+//-ldflags="-X=github.com/heroku/terraform-provider-heroku/v2/version.ProviderVersion=x.x.x"
 
 var (
 	// ProviderVersion is set during the release process to the release version of the binary, and


### PR DESCRIPTION
The use of Go modules carries with it certain expectations with respect to how versions are handled. The module reference notes:

> If the module is released at major version 2 or higher, the module path must end with a major version suffix like /v2. This may or may not be part of the subdirectory name. For example, the module with path golang.org/x/repo/sub/v2 could be in the /sub or /sub/v2 subdirectory of the repository golang.org/x/repo.

> If a module might be depended on by other modules, these rules must be followed so that the go command can find and download the module. 

source: https://golang.org/ref/mod#module-path

This provider is currently well into version 2, and the import paths are still set for version 1. While the use of this package as a dependency of another package is likely pretty rare, it does occur. 

There is an internal Heroku Terraform provider that consumes this package, and the lack of `v2` paths in the module name has been causing issues for us. The use of modules in the internal Heroku provider is fairly recent, but now that that transition has occurred, we should address this issue.

After discussions with @davidji99 and @mars, we've decided to rev this provider directly to v3. This jump will signal existing users of the provider that the change is potentially a breaking one, and will allow them to make the transition at their leisure. Existing users of the v2 provider will see no change until they want to move to v3.

This changeset updates the module path and the import path refs to v3.