### PR TITLE
Add heroku_collaborator resource

### DIFF
--- a/heroku/import_heroku_collaborator_test.go
+++ b/heroku/import_heroku_collaborator_test.go
@@ -1,0 +1,33 @@
+package heroku
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccHerokuCollaborator_importBasic(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	testUser := testAccConfig.GetNonAdminUserOrAbort(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuCollaborator_Basic(appName, testUser),
+			},
+			{
+				ResourceName:            "heroku_collaborator.foobar-collaborator",
+				ImportStateId:           buildCompositeID(appName, testUser),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"suppress_invites"},
+			},
+		},
+	})
+}

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -74,6 +74,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_app_webhook":                       resourceHerokuAppWebhook(),
 			"heroku_build":                             resourceHerokuBuild(),
 			"heroku_cert":                              resourceHerokuCert(),
+			"heroku_collaborator":                      resourceHerokuCollaborator(),
 			"heroku_config":                            resourceHerokuConfig(),
 			"heroku_domain":                            resourceHerokuDomain(),
 			"heroku_drain":                             resourceHerokuDrain(),

--- a/heroku/resource_heroku_collaborator.go
+++ b/heroku/resource_heroku_collaborator.go
@@ -1,0 +1,200 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+/**
+herokuCollaborator is a value type used to hold the details of a
+collaborator. We use this for common storage of values needed for the
+heroku.Collaborator types
+*/
+type herokuCollaborator struct {
+	Email string
+}
+
+// type collaborator is used to store all the details of a heroku collaborator
+type collaborator struct {
+	Id string // Id of the resource
+
+	AppName      string // the app the collaborator belongs to
+	Collaborator *herokuCollaborator
+	Client       *heroku.Service
+}
+
+func resourceHerokuCollaborator() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHerokuCollaboratorCreate,
+		Read:   resourceHerokuCollaboratorRead,
+		Delete: resourceHerokuCollaboratorDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceHerokuCollaboratorImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"app": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceHerokuCollaboratorCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Config).Api
+
+	opts := heroku.CollaboratorCreateOpts{}
+
+	appName := getAppName(d)
+
+	opts.User = getEmail(d)
+
+	/**
+	Setting the silent parameter to true by default. It is really an optional parameter that doesn't
+	belong in the resource's state, especially since it's not part of the collaborator GET endpoint.
+	*/
+	vs := true
+	opts.Silent = &vs
+
+	log.Printf("[DEBUG] Creating Heroku Collaborator: [%s]", opts.User)
+	createdCollaborator, err := client.CollaboratorCreate(context.TODO(), appName, opts)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(createdCollaborator.ID)
+	log.Printf("[INFO] New Collaborator ID: %s", d.Id())
+
+	return resourceHerokuCollaboratorRead(d, meta)
+}
+
+func resourceHerokuCollaboratorRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Config).Api
+
+	collaborator, err := resourceHerokuCollaboratorRetrieve(d.Id(), d.Get("app").(string), client)
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("app", collaborator.AppName)
+	d.Set("email", collaborator.Collaborator.Email)
+
+	return nil
+}
+
+func resourceHerokuCollaboratorDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Config).Api
+
+	log.Printf("[INFO] Deleting Heroku Collaborator: [%s]", d.Id())
+	_, err := client.CollaboratorDelete(context.TODO(), getAppName(d), getEmail(d))
+
+	if err != nil {
+		return fmt.Errorf("error deleting Collaborator: %s", err)
+	}
+
+	// So long as the DELETE succeeded, remove the resource from state
+	d.SetId("")
+
+	/**
+	This is borrowed from the heroku team collaborator resource where it
+	was noted that there's an edge scenario where if you immediately delete
+	a team collaborator and recreate it, the Heroku api will complain the
+	team collaborator still exists. Since these APIs are so similiar, I am
+	following a similar pattern here.
+	*/
+	log.Printf("[INFO] Begin checking if [%s] has been deleted", getEmail(d))
+	retryError := resource.Retry(10*time.Second, func() *resource.RetryError {
+		_, err := client.CollaboratorInfo(context.TODO(), getAppName(d), d.Id())
+
+		// Debug log to check
+		log.Printf("[INFO] Is error nil when GET#show collaborator? %t", err == nil)
+
+		// If err is nil, then that means the GET was successful and the collaborator still exists on the app
+		if err == nil {
+			// fmt.ErrorF does not output to log when TF_LOG=DEBUG is set to true, hence the need to execute log.PrintF for
+			// debugging purpose and fmt.ErrorF so the retry func loops
+			log.Printf("[WARNING] Collaborator [%s] exists after deletion. Checking again", getEmail(d))
+			return resource.RetryableError(err)
+		} else {
+			// if there is an error in the GET, the collaborator no longer exists.
+			return nil
+		}
+	})
+
+	if retryError != nil {
+		return fmt.Errorf("[ERROR] Collaborator [%s] still exists on [%s] after checking several times", getEmail(d), getAppName(d))
+	}
+
+	return nil
+}
+
+func resourceHerokuCollaboratorRetrieve(id string, appName string, client *heroku.Service) (*collaborator, error) {
+	collaborator := collaborator{Id: id, AppName: appName, Client: client}
+
+	err := collaborator.Update()
+
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Error retrieving collaborator: %s", err)
+	}
+
+	return &collaborator, nil
+}
+
+func (c *collaborator) Update() error {
+	var errs []error
+
+	log.Printf("[INFO] c.Id is %s", c.Id)
+
+	collaboratorInfo, err := c.Client.CollaboratorInfo(context.TODO(), c.AppName, c.Id)
+
+	if err != nil {
+		errs = append(errs, err)
+	} else {
+		c.Collaborator = &herokuCollaborator{}
+		c.Collaborator.Email = collaboratorInfo.User.Email
+		c.AppName = collaboratorInfo.App.Name
+	}
+
+	if len(errs) > 0 {
+		return &multierror.Error{Errors: errs}
+	}
+
+	return nil
+}
+
+func resourceHerokuCollaboratorImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*Config).Api
+
+	app, email, err := parseCompositeID(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	collaboratorInfo, err := client.CollaboratorInfo(context.Background(), app, email)
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(collaboratorInfo.ID)
+	d.Set("app", collaboratorInfo.App.Name)
+	d.Set("email", collaboratorInfo.User.Email)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/heroku/resource_heroku_collaborator_test.go
+++ b/heroku/resource_heroku_collaborator_test.go
@@ -1,0 +1,89 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+func TestAccHerokuCollaborator_Basic(t *testing.T) {
+	var collaborator heroku.Collaborator
+
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	testUser := testAccConfig.GetNonAdminUserOrAbort(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuCollaborator_Basic(appName, testUser),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuCollaboratorExists("heroku_collaborator.foobar-collaborator", &collaborator),
+					testAccCheckHerokuCollaboratorEmailAttribute(&collaborator, testUser),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuCollaboratorExists(n string, collaborator *heroku.Collaborator) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("[ERROR] Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("[ERROR] No Collaborator Set")
+		}
+
+		client := testAccProvider.Meta().(*Config).Api
+
+		foundCollaborator, err := client.CollaboratorInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundCollaborator.ID != rs.Primary.ID {
+			return fmt.Errorf("[ERROR] Collaborator not found")
+		}
+
+		*collaborator = *foundCollaborator
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuCollaboratorEmailAttribute(collaborator *heroku.Collaborator, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if collaborator.User.Email != n {
+			return fmt.Errorf("[ERROR] Collaborator's email incorrect. Found: %s | Expected: %s", collaborator.User.Email, n)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuCollaborator_Basic(appName, testUser string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+resource "heroku_collaborator" "foobar-collaborator" {
+	app = "${heroku_app.foobar.name}"
+	email = "%s"
+}
+`, appName, testUser)
+}

--- a/website/docs/r/collaborator.html.markdown
+++ b/website/docs/r/collaborator.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_collaborator"
+sidebar_current: "docs-heroku-resource-collaborator"
+description: |-
+  Provides the ability to add/remove collaborators from applications that are not owned by a team
+---
+
+# heroku\_collaborator
+
+A [Heroku Collaborator](https://devcenter.heroku.com/articles/platform-api-reference#collaborator) receives access to a specific app that is not owned by a team.
+
+~> **NOTE:** This resource only works for apps that are not part of a team
+
+## Example Usage
+
+```hcl
+# Create a new collaborator for the foobar application
+resource "heroku_collaborator" "foobar-collaborator" {
+	app = "${heroku_app.foobar.name}"
+	email = "collaborator@foobar.com"
+}
+```
+
+## Argument Reference
+* `app` - (Required) The name of the app that the collaborator will be added to.
+* `email` - (Required) Email address of the collaborator
+
+## Attributes Reference
+The following attributes are exported:
+
+* `id` - The ID of the collaborator
+
+## Import
+Collaborators can be imported using the combination of the application name, a colon, and the collaborator's email address
+
+For example:
+
+```
+$ terraform import heroku_collaborator.foobar-collaborator foobar_app:collaborator@foobar.com
+```


### PR DESCRIPTION
Fixes https://github.com/heroku/terraform-provider-heroku/issues/290

Adds support for a new `heroku_collaborator` resource to allow for managing access to non-team apps.

### Example HCL

```hcl
resource "heroku_collaborator" "foobar-collaborator" {
  app   = "app-name"
  email = "foobar@example.com"
}
```
