### PR TITLE
Ability to configure addon provisioning timeout

### DIFF
--- a/heroku/config.go
+++ b/heroku/config.go
@@ -52,6 +52,7 @@ func NewConfig() *Config {
 		PostAppCreateDelay:    DefaultPostAppCreateDelay,
 		PostDomainCreateDelay: DefaultPostDomainCreateDelay,
 		PostSpaceCreateDelay:  DefaultPostSpaceCreateDelay,
+		AddonCreateTimeout:    DefaultAddonCreateTimeout,
 	}
 	if logging.IsDebugOrHigher() {
 		config.DebugHTTP = true

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -21,6 +21,9 @@ const (
 	DefaultPostAppCreateDelay    = int64(5)
 	DefaultPostSpaceCreateDelay  = int64(5)
 	DefaultPostDomainCreateDelay = int64(5)
+
+	// Default custom timeouts
+	DefaultAddonCreateTimeout = int64(20)
 )
 
 type Config struct {
@@ -33,6 +36,9 @@ type Config struct {
 	PostDomainCreateDelay int64
 	PostSpaceCreateDelay  int64
 	URL                   string
+
+	// Custom Timeouts
+	AddonCreateTimeout int64
 }
 
 func (c Config) String() string {
@@ -111,6 +117,20 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 			}
 			if v, ok := delaysConfig["post_domain_create_delay"].(int); ok {
 				c.PostDomainCreateDelay = int64(v)
+			}
+		}
+	}
+
+	if v, ok := d.GetOk("timeouts"); ok {
+		vL := v.([]interface{})
+		if len(vL) > 1 {
+			return fmt.Errorf("provider configuration error: only 1 timeouts config is permitted")
+		}
+
+		for _, v := range vL {
+			timeoutsConfig := v.(map[string]interface{})
+			if v, ok := timeoutsConfig["addon_create_timeout"].(int); ok {
+				c.AddonCreateTimeout = int64(v)
 			}
 		}
 	}

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -24,16 +24,19 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("HEROKU_API_KEY", nil),
 			},
+
 			"headers": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("HEROKU_HEADERS", nil),
 			},
+
 			"url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("HEROKU_API_URL", heroku.DefaultURL),
 			},
+
 			"delays": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -57,6 +60,22 @@ func Provider() terraform.ResourceProvider {
 							Optional:     true,
 							Default:      DefaultPostDomainCreateDelay,
 							ValidateFunc: validation.IntAtLeast(0),
+						},
+					},
+				},
+			},
+
+			"timeouts": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"addon_create_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      DefaultAddonCreateTimeout,
+							ValidateFunc: validation.IntAtLeast(10),
 						},
 					},
 				},

--- a/heroku/resource_heroku_addon.go
+++ b/heroku/resource_heroku_addon.go
@@ -127,11 +127,11 @@ func resourceHerokuAddonCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for the Addon to be provisioned
-	log.Printf("[DEBUG] Waiting for Addon (%s) to be provisioned", d.Id())
+	log.Printf("[DEBUG] Waiting for Addon (%s) to be provisioned", a.ID)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"provisioning"},
 		Target:  []string{"provisioned"},
-		Refresh: AddOnStateRefreshFunc(client, app, d.Id()),
+		Refresh: AddOnStateRefreshFunc(client, app, a.ID),
 		Timeout: time.Duration(config.AddonCreateTimeout) * time.Minute,
 	}
 

--- a/heroku/resource_heroku_addon.go
+++ b/heroku/resource_heroku_addon.go
@@ -100,7 +100,8 @@ func resourceHerokuAddonCreate(d *schema.ResourceData, meta interface{}) error {
 	addonLock.Lock()
 	defer addonLock.Unlock()
 
-	client := meta.(*Config).Api
+	config := meta.(*Config)
+	client := config.Api
 
 	app := d.Get("app").(string)
 	opts := heroku.AddOnCreateOpts{
@@ -125,22 +126,23 @@ func resourceHerokuAddonCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(a.ID)
-	log.Printf("[INFO] Addon ID: %s", d.Id())
-
 	// Wait for the Addon to be provisioned
 	log.Printf("[DEBUG] Waiting for Addon (%s) to be provisioned", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"provisioning"},
 		Target:  []string{"provisioned"},
 		Refresh: AddOnStateRefreshFunc(client, app, d.Id()),
-		Timeout: 20 * time.Minute,
+		Timeout: time.Duration(config.AddonCreateTimeout) * time.Minute,
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Addon (%s) to be provisioned: %s", d.Id(), err)
 	}
 	log.Printf("[INFO] Addon provisioned: %s", d.Id())
+
+	// This should be only set after the addon provisioning has been fully completed.
+	d.SetId(a.ID)
+	log.Printf("[INFO] Addon ID: %s", d.Id())
 
 	return resourceHerokuAddonRead(d, meta)
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -126,3 +126,10 @@ The following arguments are supported:
 
   * `post_domain_create_delay` - (Optional) The number of seconds to wait after
     a domain is created. Default is to wait 5 seconds.
+
+* `timeouts` - (Optional) Define a max duration the provider will wait for certain resources
+  to be properly modified before proceeding with further action(s). Only a single `timeouts` block may be specified,
+  and it supports the following arguments:
+
+  * `addon_create_timeout` - (Optional) The number of minutes for the provider to wait for an addon to be
+  created/provisioned. Defaults to 20 minutes. Minimum required value is 10 minutes.


### PR DESCRIPTION
Often times, provisioning Heroku kafka takes longer than 20 minutes. Let's make the timeout configurable!