### PR TITLE
Provide ability to not set `all_config_vars` on heroku_app resource

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -114,9 +114,16 @@ The following arguments are supported:
   provided, it will be sourced from the `HEROKU_HEADERS` environment variable
   (if set).
 
+* `customizations` - (Optional) Various attributes altering the behavior of certain resources.
+  Only a single `customizations` block may be specified, and it supports the following arguments:
+
+  * `set_app_all_config_vars_in_state` - (Optional) Controls whether the `heroku_app.all_config_vars` attribute
+    is set in the state file. Set to `false` if you'd like not to have non-managed config vars set in state.
+    Defaults to `true`.
+
 * `delays` - (Optional) Delays help mitigate issues that can arise due to
   Heroku's eventually consistent data model. Only a single `delays` block may be
-  specified and it supports the following arguments:
+  specified, and it supports the following arguments:
 
   * `post_app_create_delay` - (Optional) The number of seconds to wait after an
     app is created. Default is to wait 5 seconds.

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -23,22 +23,28 @@ const (
 	DefaultPostDomainCreateDelay = int64(5)
 
 	// Default custom timeouts
-	DefaultAddonCreateTimeout = int64(20)
+	DefaultAddonCreateTimeout         = int64(20)
+	DefaultSetAppAllConfigVarsInState = true
 )
 
 type Config struct {
-	Api                   *heroku.Service
-	APIKey                string
-	DebugHTTP             bool
-	Email                 string
-	Headers               http.Header
+	Api       *heroku.Service
+	APIKey    string
+	DebugHTTP bool
+	Email     string
+	Headers   http.Header
+	URL       string
+
+	// Delays
 	PostAppCreateDelay    int64
 	PostDomainCreateDelay int64
 	PostSpaceCreateDelay  int64
-	URL                   string
 
-	// Custom Timeouts
+	// Timeouts
 	AddonCreateTimeout int64
+
+	// Customization
+	SetAppAllConfigVarsInState bool
 }
 
 func (c Config) String() string {
@@ -48,11 +54,12 @@ func (c Config) String() string {
 
 func NewConfig() *Config {
 	config := &Config{
-		Headers:               make(http.Header),
-		PostAppCreateDelay:    DefaultPostAppCreateDelay,
-		PostDomainCreateDelay: DefaultPostDomainCreateDelay,
-		PostSpaceCreateDelay:  DefaultPostSpaceCreateDelay,
-		AddonCreateTimeout:    DefaultAddonCreateTimeout,
+		Headers:                    make(http.Header),
+		PostAppCreateDelay:         DefaultPostAppCreateDelay,
+		PostDomainCreateDelay:      DefaultPostDomainCreateDelay,
+		PostSpaceCreateDelay:       DefaultPostSpaceCreateDelay,
+		AddonCreateTimeout:         DefaultAddonCreateTimeout,
+		SetAppAllConfigVarsInState: DefaultSetAppAllConfigVarsInState,
 	}
 	if logging.IsDebugOrHigher() {
 		config.DebugHTTP = true
@@ -103,10 +110,23 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 		c.URL = url.(string)
 	}
 
+	if v, ok := d.GetOk("customizations"); ok {
+		vL := v.([]interface{})
+		if len(vL) > 1 {
+			return fmt.Errorf("Provider configuration error: only one customizations block is permitted")
+		}
+		for _, v := range vL {
+			delaysConfig := v.(map[string]interface{})
+			if v, ok := delaysConfig["set_app_all_config_vars_in_state"].(bool); ok {
+				c.SetAppAllConfigVarsInState = v
+			}
+		}
+	}
+
 	if v, ok := d.GetOk("delays"); ok {
 		vL := v.([]interface{})
 		if len(vL) > 1 {
-			return fmt.Errorf("Provider configuration error: only 1 delays config is permitted")
+			return fmt.Errorf("Provider configuration error: only one delays block is permitted")
 		}
 		for _, v := range vL {
 			delaysConfig := v.(map[string]interface{})
@@ -125,7 +145,7 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 	if v, ok := d.GetOk("timeouts"); ok {
 		vL := v.([]interface{})
 		if len(vL) > 1 {
-			return fmt.Errorf("provider configuration error: only 1 timeouts config is permitted")
+			return fmt.Errorf("provider configuration error: only one timeouts block is permitted")
 		}
 
 		for _, v := range vL {

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -36,6 +36,21 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("HEROKU_API_URL", heroku.DefaultURL),
 			},
 
+			"customizations": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"set_app_all_config_vars_in_state": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  DefaultSetAppAllConfigVarsInState,
+						},
+					},
+				},
+			},
+
 			"delays": {
 				Type:     schema.TypeList,
 				MaxItems: 1,

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -358,7 +358,8 @@ func setAppDetails(d *schema.ResourceData, app *application) (err error) {
 }
 
 func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Config).Api
+	config := meta.(*Config)
+	client := config.Api
 
 	care := make(map[string]struct{})
 	configVars := make(map[string]string)
@@ -407,8 +408,13 @@ func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[WARN] Error setting sensitive config vars: %s", err)
 	}
 
-	if err := d.Set("all_config_vars", app.Vars); err != nil {
-		log.Printf("[WARN] Error setting all_config_vars: %s", err)
+	// Set `all_config_vars` to empty map initially. Only set this attribute
+	// if set_app_all_config_vars_in_state is `true`.
+	d.Set("all_config_vars", map[string]string{})
+	if config.SetAppAllConfigVarsInState {
+		if err := d.Set("all_config_vars", app.Vars); err != nil {
+			log.Printf("[WARN] Error setting all_config_vars: %s", err)
+		}
 	}
 
 	buildpacksErr := d.Set("buildpacks", app.Buildpacks)

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -35,6 +35,39 @@ func TestAccHerokuApp_Basic(t *testing.T) {
 						"heroku_app.foobar", "config_vars.FOO", "bar"),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "internal_routing", "false"),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "all_config_vars.%", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHerokuApp_DontSetAllConfigVars(t *testing.T) {
+	var app heroku.App
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	appStack := "heroku-20"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAppConfig_basic(appName, appStack),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
+					testAccCheckHerokuAppAttributes(&app, appName, "heroku-20"),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "name", appName),
+					resource.TestCheckResourceAttrSet(
+						"heroku_app.foobar", "uuid"),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "config_vars.FOO", "bar"),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "internal_routing", "false"),
+					resource.TestCheckResourceAttr(
+						"heroku_app.foobar", "all_config_vars.%", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
The `all_config_vars` can inadvertently set all non-terraform managed config vars
into the state file. This might fine for some but others may like the state file
to only include config var explicitly defined in a configuration. A solution here
is a provider block level attribute that will prevent the `heroku_app` resource from
setting this particular variable. In such a scenario, the attribute's value will be
an empty map.