### PR TITLE
Update acceptance-tests.yml to use Go 1.16

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -17,10 +17,10 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go 1.14
+    - name: Install Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.16
       id: go
 
     - uses: actions/checkout@master


### PR DESCRIPTION
Since `release.yml` will use Go 1.16 to generate darwin/arm64 binaries, it make sense to also run the acceptance tests using Go 1.16.