### PR TITLE
Remove deprecated heroku_space trusted_ip_ranges attribute

### DIFF
--- a/heroku/data_source_heroku_app_test.go
+++ b/heroku/data_source_heroku_app_test.go
@@ -128,7 +128,6 @@ resource "heroku_space" "foobar" {
   name = "%s"
   organization = "%s"
 	region = "virginia"
-	trusted_ip_ranges = [ "0.0.0.0/0" ]
 }
 
 resource "heroku_app" "foobar" {
@@ -148,7 +147,6 @@ resource "heroku_space" "foobar" {
   name = "%s"
   organization = "%s"
 	region = "virginia"
-	trusted_ip_ranges = [ "0.0.0.0/0" ]
 }
 
 resource "heroku_app" "foobar" {

--- a/heroku/data_source_heroku_space.go
+++ b/heroku/data_source_heroku_space.go
@@ -56,14 +56,6 @@ func dataSourceHerokuSpace() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-
-			"trusted_ip_ranges": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 		},
 	}
 }
@@ -77,7 +69,7 @@ func dataSourceHerokuSpaceRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	space := spaceRaw.(*spaceWithRanges)
+	space := spaceRaw.(*spaceWithNAT)
 
 	d.SetId(name)
 	d.Set("state", space.State)

--- a/heroku/resource_heroku_space.go
+++ b/heroku/resource_heroku_space.go
@@ -11,10 +11,9 @@ import (
 	heroku "github.com/heroku/heroku-go/v5"
 )
 
-type spaceWithRanges struct {
+type spaceWithNAT struct {
 	heroku.Space
-	TrustedIPRanges []string
-	NAT             heroku.SpaceNAT
+	NAT heroku.SpaceNAT
 }
 
 func resourceHerokuSpace() *schema.Resource {
@@ -74,17 +73,6 @@ func resourceHerokuSpace() *schema.Resource {
 				Default:  false,
 				ForceNew: true,
 			},
-
-			"trusted_ip_ranges": {
-				Type:       schema.TypeSet,
-				Computed:   true,
-				Optional:   true,
-				MinItems:   0,
-				Deprecated: "This attribute is deprecated in favor of heroku_space_inbound_ruleset. Using both at the same time will likely cause unexpected behavior.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 		},
 	}
 }
@@ -140,32 +128,6 @@ func resourceHerokuSpaceCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error waiting for Space (%s) to become available: %s", d.Id(), err)
 	}
 
-	if ranges, ok := d.GetOk("trusted_ip_ranges"); ok {
-		ips := ranges.(*schema.Set)
-
-		var rules []*struct {
-			Action string `json:"action" url:"action,key"`
-			Source string `json:"source" url:"source,key"`
-		}
-
-		for _, r := range ips.List() {
-			rules = append(rules, &struct {
-				Action string `json:"action" url:"action,key"`
-				Source string `json:"source" url:"source,key"`
-			}{
-				Action: "allow",
-				Source: r.(string),
-			})
-		}
-
-		opts := heroku.InboundRulesetCreateOpts{Rules: rules}
-		_, err := client.InboundRulesetCreate(context.TODO(), space.ID, opts)
-		if err != nil {
-			return fmt.Errorf("Error creating Trusted IP Ranges for Space (%s): %s", space.ID, err)
-		}
-		log.Printf("[DEBUG] Set Trusted IP Ranges to %s for Space %s", ips.List(), d.Id())
-	}
-
 	config := meta.(*Config)
 	time.Sleep(time.Duration(config.PostSpaceCreateDelay) * time.Second)
 
@@ -180,12 +142,11 @@ func resourceHerokuSpaceRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	space := spaceRaw.(*spaceWithRanges)
+	space := spaceRaw.(*spaceWithNAT)
 
 	d.Set("name", space.Name)
 	d.Set("organization", space.Organization.Name)
 	d.Set("region", space.Region.Name)
-	d.Set("trusted_ip_ranges", space.TrustedIPRanges)
 	d.Set("outbound_ips", space.NAT.Sources)
 	d.Set("shield", space.Shield)
 	d.Set("cidr", space.CIDR)
@@ -207,31 +168,6 @@ func resourceHerokuSpaceUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if d.HasChange("trusted_ip_ranges") {
-		var rules []*struct {
-			Action string `json:"action" url:"action,key"`
-			Source string `json:"source" url:"source,key"`
-		}
-		ranges := d.Get("trusted_ip_ranges").(*schema.Set)
-		for _, r := range ranges.List() {
-			rules = append(rules, &struct {
-				Action string `json:"action" url:"action,key"`
-				Source string `json:"source" url:"source,key"`
-			}{
-				Action: "allow",
-				Source: r.(string),
-			})
-		}
-
-		opts := heroku.InboundRulesetCreateOpts{Rules: rules}
-		_, err := client.InboundRulesetCreate(context.TODO(), d.Id(), opts)
-		if err != nil {
-			return fmt.Errorf("Error creating Trusted IP Ranges for Space (%s): %s", d.Id(), err)
-		}
-
-		d.Set("trusted_ip_ranges", ranges)
 	}
 
 	return nil
@@ -260,24 +196,13 @@ func SpaceStateRefreshFunc(client *heroku.Service, id string) resource.StateRefr
 			return nil, "", err
 		}
 
-		s := spaceWithRanges{
+		s := spaceWithNAT{
 			Space: *space,
 		}
 
 		if space.State == "allocating" {
 			log.Printf("[DEBUG] Still allocating: %s (%s)", space.State, id)
 			return &s, space.State, nil
-		}
-
-		ruleset, err := client.InboundRulesetCurrent(context.TODO(), id)
-		if err != nil {
-			log.Printf("[DEBUG] %s (%s)", err, id)
-			return nil, "", err
-		}
-
-		s.TrustedIPRanges = make([]string, len(ruleset.Rules))
-		for i, r := range ruleset.Rules {
-			s.TrustedIPRanges[i] = r.Source
 		}
 
 		nat, err := client.SpaceNATInfo(context.TODO(), id)
@@ -287,7 +212,6 @@ func SpaceStateRefreshFunc(client *heroku.Service, id string) resource.StateRefr
 		s.NAT = *nat
 
 		log.Printf("[DEBUG] Outbound NAT IPs: %s (%s)", s.NAT.Sources, id)
-		log.Printf("[DEBUG] Trusted IP ranges: %s (%s)", s.TrustedIPRanges, id)
 
 		return &s, space.State, nil
 	}

--- a/heroku/resource_heroku_space_test.go
+++ b/heroku/resource_heroku_space_test.go
@@ -3,7 +3,6 @@ package heroku
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -30,7 +29,6 @@ func TestAccHerokuSpace_Basic(t *testing.T) {
 				Config:       testAccCheckHerokuSpaceConfig_basic(spaceName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSpaceExists("heroku_space.foobar", &space),
-					resource.TestCheckResourceAttr("heroku_space.foobar", "trusted_ip_ranges.#", "2"),
 					testAccCheckHerokuSpaceAttributes(&space, spaceName),
 					resource.TestCheckResourceAttrSet(
 						"heroku_space.foobar", "outbound_ips.#"),
@@ -67,38 +65,6 @@ func TestAccHerokuSpace_Shield(t *testing.T) {
 					testAccCheckHerokuSpaceAttributes(&space, spaceName),
 					resource.TestCheckResourceAttr(
 						"heroku_space.foobar", "shield", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccHerokuSpace_IPRange(t *testing.T) {
-	var space heroku.Space
-	spaceName := fmt.Sprintf("tftest1-%s", acctest.RandString(10))
-	org := testAccConfig.GetAnyOrganizationOrSkip(t)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckHerokuSpaceDestroy,
-		Steps: []resource.TestStep{
-			{
-				ResourceName: "heroku_space.foobar",
-				Config:       testAccCheckHerokuSpaceConfig_iprange(spaceName, org, []string{"8.8.8.8/32"}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckHerokuSpaceExists("heroku_space.foobar", &space),
-					resource.TestCheckResourceAttr("heroku_space.foobar", "trusted_ip_ranges.#", "1"),
-				),
-			},
-			{
-				ResourceName: "heroku_space.foobar",
-				Config:       testAccCheckHerokuSpaceConfig_iprange(spaceName, org, []string{"8.8.8.8/32", "8.8.8.0/24"}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckHerokuSpaceExists("heroku_space.foobar", &space),
-					resource.TestCheckResourceAttr("heroku_space.foobar", "trusted_ip_ranges.#", "2"),
 				),
 			},
 		},
@@ -143,10 +109,6 @@ resource "heroku_space" "foobar" {
   name = "%s"
   organization = "%s"
   region = "virginia"
-  trusted_ip_ranges = [
-    "8.8.8.8/32",
-    "8.8.8.0/24",
-  ]
 }
 `, spaceName, orgName)
 }
@@ -160,18 +122,6 @@ resource "heroku_space" "foobar" {
   shield       = true
 }
 `, spaceName, orgName)
-}
-
-func testAccCheckHerokuSpaceConfig_iprange(spaceName, orgName string, ips []string) string {
-	ipsStr := fmt.Sprintf("\"%s\"", strings.Join(ips, "\", \""))
-	return fmt.Sprintf(`
-resource "heroku_space" "foobar" {
-  name         = "%s"
-  organization = "%s"
-  region       = "virginia"
-  trusted_ip_ranges = [%s]
-}
-`, spaceName, orgName, ipsStr)
 }
 
 func testAccCheckHerokuSpaceConfig_cidr(spaceName, orgName string, cidr string) string {


### PR DESCRIPTION
Fixes #306 by pruning out long-deprecated code that causes inconsistent results for `heroku_space_inbound_ruleset` resource.