### PR TITLE
Ability for `heroku_team_collaborator` to handle manual deletions

### DIFF
--- a/heroku/resource_heroku_team_collaborator.go
+++ b/heroku/resource_heroku_team_collaborator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -123,6 +124,11 @@ func resourceHerokuTeamCollaboratorRead(d *schema.ResourceData, meta interface{}
 	teamCollaborator, err := resourceHerokuTeamCollaboratorRetrieve(d.Id(), d.Get("app").(string), client)
 
 	if err != nil {
+		if strings.Contains(err.Error(), "Couldn't find that user") {
+			// If user cannot be found, remove the resource from state.
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Say someone has this defined in their configuration:

```hcl
resource "heroku_team_collaborator" "userx" {
	app = heroku_app.foobar.name
	email = "userx@mycompany.com"
	permissions = ["view", "operate", "manage"]
}
```

Sometimes, `userx@mycompany.com` might be removed from `heroku_app.foobar` manually outside of Terraform. While manual changes to a Terraform'ed resource are not ideal, this PR will alter the behavior of `heroku_team_collaborator` to remove the resource form state if it has been deleted remotely.