### PR TITLE
Improvements to `heroku_ssl` resource

### DIFF
--- a/docs/resources/cert.md
+++ b/docs/resources/cert.md
@@ -3,12 +3,14 @@ layout: "heroku"
 page_title: "Heroku: heroku_cert"
 sidebar_current: "docs-heroku-resource-cert"
 description: |-
-  Provides a Heroku SSL certificate resource. It allows to set a given certificate for a Heroku app. This resource is deprecated in favor of `heroku_ssl`.
+  Provides a Heroku SSL certificate resource to manage a certificate for a Heroku app.
 ---
 
 # heroku\_cert
 
-Provides a Heroku SSL certificate resource. It allows to set a given certificate for a Heroku app.This resource is deprecated in favor of `heroku_ssl`.
+This resource manages an SSL certificate for a Heroku app.
+
+!> **WARNING:** This resource is deprecated in favor of `heroku_ssl`.
 
 ## Example Usage
 

--- a/docs/resources/ssl.md
+++ b/docs/resources/ssl.md
@@ -82,8 +82,9 @@ The following arguments are supported:
 
 * `app_id` - (Required) The Heroku app UUID to add to.
 * `certificate_chain` - (Required) The certificate chain to add.
-* `private_key` - (Required) The private key for a given certificate chain.
-  This attribute value does not get displayed in logs or regular output.
+* `private_key` - (Optional) The private key for a given certificate chain. You **must** set this attribute when creating or
+  updating an SSL resource. However, **do not** set a value for this attribute if you are initially importing an existing
+  SSL resource. The attribute value does not get displayed in logs or regular output.
 
 ## Attributes Reference
 

--- a/docs/resources/ssl.md
+++ b/docs/resources/ssl.md
@@ -3,12 +3,16 @@ layout: "heroku"
 page_title: "Heroku: heroku_ssl"
 sidebar_current: "docs-heroku-resource-ssl"
 description: |-
-  Provides a Heroku SSL certificate resource. It allows to set a given certificate for a domain on a Heroku app.
+  Provides a Heroku SSL certificate resource to manage a certificate for a Heroku app.
 ---
 
 # heroku\_ssl
 
-Provides a Heroku SSL certificate resource. It allows to set a given certificate for a domain on a Heroku app.
+This resource manages an SSL certificate for a Heroku app.
+
+-> **IMPORTANT!**
+This resource renders the "private_key" attribute in plain-text in your state file.
+Please ensure that your state file is properly secured and encrypted at rest.
 
 ## Example Usage
 
@@ -33,15 +37,17 @@ resource "heroku_formation" "web" {
   type = "web"
   size = "hobby"
   quantity = 1
+
   # Wait until the build has completed before attempting to scale
   depends_on = [heroku_build.default]
 }
 
 # Create the certificate
 resource "heroku_ssl" "one" {
-  app = heroku_app.default.name
+  app_id = heroku_app.default.uuid
   certificate_chain = file("server.crt")
   private_key = file("server.key")
+
   # Wait until the process_tier changes to hobby before attempting to create a cert
   depends_on = [heroku_formation.web]
 }
@@ -55,7 +61,7 @@ resource "heroku_domain" "one" {
 
 # Create another certificate
 resource "heroku_ssl" "two" {
-  app = heroku_app.default.name
+  app_id = heroku_app.default.uuid
   certificate_chain = file("server.crt")
   private_key = file("server.key")
   # Wait until the process_tier changes to hobby before attempting to create a cert
@@ -74,9 +80,10 @@ resource "heroku_domain" "two" {
 
 The following arguments are supported:
 
-* `app` - (Required) The Heroku app to add to.
-* `certificate_chain` - (Required) The certificate chain to add
-* `private_key` - (Required) The private key for a given certificate chain
+* `app_id` - (Required) The Heroku app UUID to add to.
+* `certificate_chain` - (Required) The certificate chain to add.
+* `private_key` - (Required) The private key for a given certificate chain.
+  This attribute value does not get displayed in logs or regular output.
 
 ## Attributes Reference
 
@@ -87,7 +94,9 @@ The following attributes are exported:
 
 ## Importing
 
-When importing a Heroku ssl resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `production-api` with a certificate ID of `b85d9224-310b-409b-891e-c903f5a40568`, you would import it as:
+An existing SSL resource can be imported using a composite value of the app name and certificate UUID separated by a colon.
+
+For example:
 
 ```
 $ terraform import heroku_ssl.production_api production-api:b85d9224-310b-409b-891e-c903f5a40568

--- a/heroku/import_heroku_ssl_test.go
+++ b/heroku/import_heroku_ssl_test.go
@@ -25,10 +25,11 @@ func TestAccHerokuSSL_importBasic(t *testing.T) {
 				Config: testAccCheckHerokuSSLConfig(appName, certFile, keyFile),
 			},
 			{
-				ResourceName:        "heroku_ssl.one",
-				ImportStateIdPrefix: appName + ":",
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:            "heroku_ssl.one",
+				ImportStateIdPrefix:     appName + ":",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"private_key"},
 			},
 		},
 	})

--- a/heroku/import_heroku_ssl_test.go
+++ b/heroku/import_heroku_ssl_test.go
@@ -28,6 +28,7 @@ func TestAccHerokuSSL_importBasic(t *testing.T) {
 				ResourceName:        "heroku_ssl.one",
 				ImportStateIdPrefix: appName + ":",
 				ImportState:         true,
+				ImportStateVerify:   true,
 			},
 		},
 	})

--- a/heroku/resource_heroku_domain_test.go
+++ b/heroku/resource_heroku_domain_test.go
@@ -215,7 +215,7 @@ resource "heroku_formation" "web" {
 }
 
 resource "heroku_ssl" "one" {
-  app = "${heroku_app.one.id}"
+  app_id = heroku_app.one.uuid
   certificate_chain="${file("%s")}"
   private_key="${file("%s")}"
   # Wait until the process_tier changes to hobby before attempting to create a cert
@@ -262,14 +262,14 @@ resource "heroku_formation" "web" {
 }
 
 resource "heroku_ssl" "one" {
-  app = "${heroku_app.one.id}"
+  app_id = heroku_app.one.uuid
   certificate_chain="${file("%s")}"
   private_key="${file("%s")}"
   depends_on = [heroku_formation.web]
 }
 
 resource "heroku_ssl" "two" {
-  app = "${heroku_app.one.id}"
+  app_id = heroku_app.one.uuid
   certificate_chain="${file("%s")}"
   private_key="${file("%s")}"
   depends_on = [heroku_formation.web]
@@ -314,7 +314,7 @@ resource "heroku_formation" "web" {
 }
 
 resource "heroku_ssl" "one" {
-  app = "${heroku_app.one.id}"
+  app_id = heroku_app.one.uuid
   certificate_chain="${file("%s")}"
   private_key="${file("%s")}"
   depends_on = [heroku_formation.web]

--- a/heroku/resource_heroku_pipeline_config_var.go
+++ b/heroku/resource_heroku_pipeline_config_var.go
@@ -25,7 +25,7 @@ func resourceHerokuPipelineConfigVar() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateUUID,
+				ValidateFunc: validation.IsUUID,
 			},
 
 			"pipeline_stage": {

--- a/heroku/resource_heroku_pipeline_coupling.go
+++ b/heroku/resource_heroku_pipeline_coupling.go
@@ -34,7 +34,7 @@ func resourceHerokuPipelineCoupling() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateUUID,
+				ValidateFunc: validation.IsUUID,
 			},
 			"stage": {
 				Type:     schema.TypeString,

--- a/heroku/resource_heroku_ssl.go
+++ b/heroku/resource_heroku_ssl.go
@@ -3,6 +3,7 @@ package heroku
 import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -24,9 +25,10 @@ func resourceHerokuSSL() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"app_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
 			},
 
 			"certificate_chain": {
@@ -36,8 +38,8 @@ func resourceHerokuSSL() *schema.Resource {
 
 			"private_key": {
 				Type:      schema.TypeString,
-				Required:  true,
 				Sensitive: true,
+				Optional:  true, // This should be 'Required' using 'Optional' to make things easier during resource import.
 			},
 
 			"name": {
@@ -65,7 +67,6 @@ func resourceHerokuSSLImport(d *schema.ResourceData, meta interface{}) ([]*schem
 	d.Set("app_id", ep.App.ID)
 	d.Set("certificate_chain", ep.CertificateChain)
 	d.Set("name", ep.Name)
-	// TODO: need to add d.Set("private_key")
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/heroku/resource_heroku_ssl_test.go
+++ b/heroku/resource_heroku_ssl_test.go
@@ -40,6 +40,8 @@ func TestAccHerokuSSL_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSSLExists("heroku_ssl.one", &endpoint),
 					testAccCheckHerokuSSLCertificateChain(&endpoint, certificateChain2),
+					resource.TestCheckResourceAttr("heroku_ssl.one", "certificate_chain", certificateChain2),
+					resource.TestCheckResourceAttrSet("heroku_ssl.one", "name"),
 				),
 			},
 			{
@@ -48,6 +50,8 @@ func TestAccHerokuSSL_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSSLExists("heroku_ssl.one", &endpoint),
 					testAccCheckHerokuSSLCertificateChain(&endpoint, certificateChain),
+					resource.TestCheckResourceAttr("heroku_ssl.one", "certificate_chain", certificateChain),
+					resource.TestCheckResourceAttrSet("heroku_ssl.one", "name"),
 				),
 			},
 		},

--- a/heroku/resource_heroku_ssl_test.go
+++ b/heroku/resource_heroku_ssl_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/heroku/terraform-provider-heroku/v4/helper/test"
 )
 
-func TestAccHerokuSSL(t *testing.T) {
+func TestAccHerokuSSL_basic(t *testing.T) {
 	var endpoint heroku.SniEndpoint
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
@@ -62,20 +62,20 @@ resource "heroku_app" "one" {
 }
 
 resource "heroku_slug" "one" {
-    app = "${heroku_app.one.id}"
-    file_path = "test-fixtures/slug.tgz"
-    process_types = {
-      web = "ruby server.rb"
-    }
+  app = heroku_app.one.id
+  file_path = "test-fixtures/slug.tgz"
+  process_types = {
+    web = "ruby server.rb"
+  }
 }
 
 resource "heroku_app_release" "one" {
-  app = "${heroku_app.one.id}"
-  slug_id = "${heroku_slug.one.id}"
+  app = heroku_app.one.id
+  slug_id = heroku_slug.one.id
 }
 
 resource "heroku_formation" "web" {
-  app = "${heroku_app.one.id}"
+  app = heroku_app.one.id
   type = "web"
   size = "hobby"
   quantity = 1
@@ -83,9 +83,9 @@ resource "heroku_formation" "web" {
 }
 
 resource "heroku_ssl" "one" {
-  app = "${heroku_app.one.id}"
-  certificate_chain="${file("%s")}"
-  private_key="${file("%s")}"
+  app_id = heroku_app.one.uuid
+  certificate_chain = file("%s")
+  private_key = file("%s")
   depends_on = [heroku_formation.web]
 }`, appName, certFile, keyFile))
 }
@@ -133,7 +133,7 @@ func testAccCheckHerokuSSLExists(n string, endpoint *heroku.SniEndpoint) resourc
 
 		client := testAccProvider.Meta().(*Config).Api
 
-		foundEndpoint, err := client.SniEndpointInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
+		foundEndpoint, err := client.SniEndpointInfo(context.TODO(), rs.Primary.Attributes["app_id"], rs.Primary.ID)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
FYI @mikehale I made a few modifications to this resource:

- Rename `app` to `app_id`. There have been a few issues over the years of people complaining about app name changes causing unintentional downstream resource recreations. To address this going forward for new resources, I've been making sure the resource schema uses and validates the app UUID.
- I made `private_key` optional but clarified in the doc that it must be set during resource creation/modifications. The API unfortunately does not return the `private_key` in the JSON response. This makes things difficult during resource import as the next `apply` after `import` will register a `plan` diff indicating Terraform wishes to change `private_key` from `null --> <the_actual_value>`. I do not want to smush the private_key in the resource import ID either.