### PR TITLE
Fix heroku_domain so sni_endpoint_id is not cleared on update

### DIFF
--- a/heroku/resource_heroku_domain.go
+++ b/heroku/resource_heroku_domain.go
@@ -42,6 +42,7 @@ func resourceHerokuDomain() *schema.Resource {
 			"sni_endpoint_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 		},
 	}


### PR DESCRIPTION
Currently, when `sni_endpoint_id` is not provided by the configuration, the call to `d.HasChange("sni_endpoint_id")` will always determine that a change has occurred, as the API will return the actual value from `do.SniEndpoint.ID` but the "desired" configuration value will be unset. Thus in this case, updates will always attempt to modify Heroku to set the value to the empty string, which Heroku disallows (and is semantically incorrect).

By making `sni_endpoint_id` both `Optional` and `Computed`, it can still be explicitly set via configuration, but otherwise Terraform use the value from creation (which is automatically determined by Heroku) as the set value for updates. Since this will match the current value from the API, no update will be attempted, which is the correct behavior.