### PR TITLE
Ability for `heroku_team_collaborator` to handle users that already exist on the app

### DIFF
--- a/heroku/resource_heroku_app_config_association_test.go
+++ b/heroku/resource_heroku_app_config_association_test.go
@@ -113,8 +113,8 @@ resource "heroku_app_config_association" "foobar-config" {
 func testAccCheckHerokuAppConfigAssociation_Advanced(org, appName string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
-    name = "%s"
-    region = "us"
+  name = "%s"
+  region = "us"
   organization {
     name = "%s"
   }
@@ -133,9 +133,9 @@ resource "heroku_config" "config" {
 }
 
 resource "heroku_app_config_association" "foobar-config" {
-    app_id = "${heroku_app.foobar.id}"
+    app_id = heroku_app.foobar.id
 
-    vars = "${heroku_config.config.vars}"
-    sensitive_vars = "${heroku_config.config.sensitive_vars}"
+    vars = heroku_config.config.vars
+    sensitive_vars = heroku_config.config.sensitive_vars
 }`, appName, org)
 }


### PR DESCRIPTION
From my experience, people often manually add users to Heroku team apps outside of Terraform for a number of reasons. When the Terraform configuration is updated to reflect such out-of-band changes, people need to `import` the resource first before executing an `apply`. This PR will handle this scenario but checking for a specific error returned from resource creation indicating that the target user is on the target app. If so, find the collaborator ID, set it to the resource ID, and proceed with state refresh.