### PR TITLE
Modify heroku_drain to accept URLs that pass in basic auth

### DIFF
--- a/docs/resources/drain.md
+++ b/docs/resources/drain.md
@@ -25,12 +25,27 @@ resource "heroku_drain" "default" {
 }
 ```
 
+```hcl-terraform
+resource "heroku_app" "foobar" {
+  name = "foobar"
+  region = "us"
+}
+
+resource "heroku_drain" "default" {
+  app = heroku_app.foobar.id
+  sensitive_url = "https://user:pass@terraform.example.com"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `url` - (Required) The URL for Heroku to drain your logs to.
 * `app` - (Required) The Heroku app to link to.
+* `url` - (Optional) The URL for Heroku to drain your logs to. Either `url` or `sensitive_url` must be defined.
+* `sensitive_url` - (Optional) The URL for Heroku to drain your logs to. The main difference between `sensitive_url` and `url`
+is `sensitive_url` outputs are redacted, with <sensitive> displayed in place of their value during a `terraform apply`
+or `terraform refresh`. Either `url` or `sensitive_url` must be defined.
 
 ## Attributes Reference
 
@@ -40,8 +55,18 @@ The following attributes are exported:
 
 ## Importing
 
-When importing a Heroku drain resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `production-api` with a drain ID of `b85d9224-310b-409b-891e-c903f5a40568`, you would import it as: 
+When importing a Heroku drain resource, the ID must be built using the app name colon the unique ID from the Heroku API.
+For an app named `production-api` with a drain ID of `b85d9224-310b-409b-891e-c903f5a40568` and the `url` attribute value
+defined for the resource, you would import it as:
 
 ```
 $ terraform import heroku_drain.production_api production-api:b85d9224-310b-409b-891e-c903f5a40568
+```
+
+When importing a Heroku drain resource, the ID must be built using the app name colon the unique ID from the Heroku API.
+For an app named `production-api` with a drain ID of `b85d9224-310b-409b-891e-c903f5a40568` and the `sensitive_url` attribute value
+defined for the resource, you would import it as:
+
+```
+$ terraform import heroku_drain.production_api production-api:b85d9224-310b-409b-891e-c903f5a40568:sensitive
 ```

--- a/heroku/import_heroku_drain_test.go
+++ b/heroku/import_heroku_drain_test.go
@@ -2,6 +2,7 @@ package heroku
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -23,7 +24,40 @@ func TestAccHerokuDrain_importBasic(t *testing.T) {
 				ResourceName:        "heroku_drain.foobar",
 				ImportStateIdPrefix: appName + ":",
 				ImportState:         true,
+				ImportStateVerify:   true,
 			},
 		},
 	})
+}
+
+func TestAccHerokuDrain_importBasicWithSensitiveURL(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuDrainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuDrainConfig_basicWithSensitiveURL(appName),
+			},
+			{
+				ResourceName:      "heroku_drain.foobar",
+				ImportStateIdFunc: testAccHerokuDrainImportStateIDFunc("heroku_drain.foobar"),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccHerokuDrainImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("[ERROR] Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s:%s:sensitive", rs.Primary.Attributes["app"], rs.Primary.Attributes["id"]), nil
+	}
 }

--- a/heroku/resource_heroku_drain.go
+++ b/heroku/resource_heroku_drain.go
@@ -24,10 +24,9 @@ func resourceHerokuDrain() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"app": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				AtLeastOneOf: []string{"url", "sensitive_url"},
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"url": {
@@ -71,8 +70,11 @@ func resourceHerokuDrainImport(d *schema.ResourceData, meta interface{}) ([]*sch
 		app = result[0]
 		id = result[1]
 
-		if result[3] == "sensitive" {
+		if result[2] == "sensitive" {
 			isSensitive = true
+		} else {
+			return nil, fmt.Errorf("to import a heroku_drain with a sensitive url, please use 'sensitive', not '%s'",
+				result[2])
 		}
 	default:
 		return nil, fmt.Errorf("the heroku_drain import ID should consist of 2 or 3 strings separated by a colon")


### PR DESCRIPTION
It is possible to define a log drain URL that has a username and password: https://devcenter.heroku.com/articles/log-drains#https-drains<br><br>We need to modify heroku_drain to be able to safely accept such a value.