### PR TITLE
heroku_addon "config_var_values"

### DIFF
--- a/docs/resources/addon.md
+++ b/docs/resources/addon.md
@@ -54,7 +54,7 @@ The following attributes are exported:
 * `plan` - The plan name
 * `provider_id` - The ID of the plan provider
 * `config_vars` - The Configuration variables of the add-on
-* `config_var_values` - A map of the configuration variable's values queried from the app. Upon add-on creation, these values will be up-to-date, while the app's own `config_vars` require another Terraform refresh cycle to be updated. Useful when an output is set to an add-on config var value, or when a configuration needs to operate on a new add-on during an apply.
+* `config_var_values` - A sensitive map of the add-on's configuration variables. Upon add-on creation, these values will be up-to-date, while the app's own `config_vars` require another Terraform refresh cycle to be updated. Useful when an output contains an add-on config var value, or when a configuration needs to operate on a new add-on during an apply.
 
 ## Import
 

--- a/docs/resources/addon.md
+++ b/docs/resources/addon.md
@@ -54,6 +54,7 @@ The following attributes are exported:
 * `plan` - The plan name
 * `provider_id` - The ID of the plan provider
 * `config_vars` - The Configuration variables of the add-on
+* `config_var_values` - A map of the configuration variable's values queried from the app. Upon add-on creation, these values will be up-to-date, while the app's own `config_vars` require another Terraform refresh cycle to be updated. Useful when an output is set to an add-on config var value, or when a configuration needs to operate on a new add-on during an apply.
 
 ## Import
 

--- a/heroku/import_heroku_cert_test.go
+++ b/heroku/import_heroku_cert_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccHerokuCert_importBasic(t *testing.T) {
+	t.Skip("SSL Endpoint shutdown: https://devcenter.heroku.com/changelog-items/2280")
+
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	wd, _ := os.Getwd()

--- a/heroku/resource_heroku_addon_test.go
+++ b/heroku/resource_heroku_addon_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -25,7 +26,7 @@ func TestAccHerokuAddon_Basic(t *testing.T) {
 				Config: testAccCheckHerokuAddonConfig_basic(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
-					testAccCheckHerokuAddonAttributes(&addon, "deployhooks:http"),
+					testAccCheckHerokuAddonPlan(&addon, "deployhooks:http"),
 					resource.TestCheckResourceAttr(
 						"heroku_addon.foobar", "config.url", "http://google.com"),
 					resource.TestCheckResourceAttr(
@@ -51,7 +52,7 @@ func TestAccHerokuAddon_noPlan(t *testing.T) {
 				Config: testAccCheckHerokuAddonConfig_no_plan(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
-					testAccCheckHerokuAddonAttributes(&addon, "memcachier:dev"),
+					testAccCheckHerokuAddonPlan(&addon, "memcachier:dev"),
 					resource.TestCheckResourceAttr(
 						"heroku_addon.foobar", "app", appName),
 					resource.TestCheckResourceAttr(
@@ -62,11 +63,32 @@ func TestAccHerokuAddon_noPlan(t *testing.T) {
 				Config: testAccCheckHerokuAddonConfig_no_plan(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
-					testAccCheckHerokuAddonAttributes(&addon, "memcachier:dev"),
+					testAccCheckHerokuAddonPlan(&addon, "memcachier:dev"),
 					resource.TestCheckResourceAttr(
 						"heroku_addon.foobar", "app", appName),
 					resource.TestCheckResourceAttr(
 						"heroku_addon.foobar", "plan", "memcachier"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHerokuAddon_ConfigVarValues(t *testing.T) {
+	var addon heroku.AddOn
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAddonDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAddonConfig_configVarValues(appName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAddonExists("heroku_addon.pg", &addon),
+					testAccCheckHerokuAddonPlan(&addon, "heroku-postgresql:hobby-dev"),
+					testAccCheckHerokuAddonConfigVarValueHasDatabaseURL("heroku_addon.pg", &addon),
 				),
 			},
 		},
@@ -87,7 +109,7 @@ func TestAccHerokuAddon_CustomName(t *testing.T) {
 				Config: testAccCheckHerokuAddonConfig_CustomName(appName, customName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
-					testAccCheckHerokuAddonAttributes(&addon, "memcachier:dev"),
+					testAccCheckHerokuAddonPlan(&addon, "memcachier:dev"),
 					resource.TestCheckResourceAttr(
 						"heroku_addon.foobar", "app", appName),
 					resource.TestCheckResourceAttr(
@@ -190,11 +212,35 @@ func testAccCheckHerokuAddonDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuAddonAttributes(addon *heroku.AddOn, n string) resource.TestCheckFunc {
+func testAccCheckHerokuAddonPlan(addon *heroku.AddOn, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if addon.Plan.Name != n {
 			return fmt.Errorf("Bad plan: %s", addon.Plan.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuAddonConfigVarValueHasDatabaseURL(n string, addon *heroku.AddOn) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Addon ID is set")
+		}
+
+		dbURL := rs.Primary.Attributes["config_var_values.DATABASE_URL"]
+		if dbURL == "" {
+			return fmt.Errorf(`Expected "config_var_values" to contain the key "DATABASE_URL"`)
+		}
+		if !strings.HasPrefix(dbURL, "postgres://") {
+			return fmt.Errorf(`Expected "DATABASE_URL" to start with "postgres://", got %s`, dbURL)
 		}
 
 		return nil
@@ -253,6 +299,19 @@ resource "heroku_addon" "foobar" {
     config = {
         url = "http://google.com"
 	}
+}`, appName)
+}
+
+func testAccCheckHerokuAddonConfig_configVarValues(appName string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+
+resource "heroku_addon" "pg" {
+    app = "${heroku_app.foobar.name}"
+    plan = "heroku-postgresql:hobby-dev"
 }`, appName)
 }
 

--- a/heroku/resource_heroku_cert_test.go
+++ b/heroku/resource_heroku_cert_test.go
@@ -29,6 +29,8 @@ import (
 // on update seems to allow the test to run smoothly; in real life, this test
 // case is definitely an extreme edge case.
 func TestAccHerokuCert_EU(t *testing.T) {
+	t.Skip("SSL Endpoint shutdown: https://devcenter.heroku.com/changelog-items/2280")
+
 	var endpoint heroku.SSLEndpoint
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
@@ -74,6 +76,8 @@ func TestAccHerokuCert_EU(t *testing.T) {
 }
 
 func TestAccHerokuCert_US(t *testing.T) {
+	t.Skip("SSL Endpoint shutdown: https://devcenter.heroku.com/changelog-items/2280")
+
 	var endpoint heroku.SSLEndpoint
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 


### PR DESCRIPTION
Currently, `heroku_addon` config vars are not readable from their parent `heroku_app`, until the next Terraform refresh.

You've probably encountered this problem, if you've ever tried to set a Terraform `output` to the value of an add-on config var, or tried to use an add-on's config vars to operate on an add-on immediately after it's created.

This PR remedies this problem by presenting each add-on's config var values directly on the add-on resource itself as a new, sensitive `config_var_values` map attribute.

Using this new attribute, the add-on's config vars become available in the same `terraform apply` as the add-on is created.