### PR TITLE
Fix goreleaser unsupported windows/arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,8 @@ builds:
         goarch: arm
       - goos: openbsd
         goarch: arm64
+      - goos: windows
+        goarch: arm64
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip


### PR DESCRIPTION
Fix for error in [GitHub Action publish job](https://github.com/heroku/terraform-provider-heroku/runs/7344679740?check_suite_focus=true):
```
  •building binaries
    • building                                       binary=dist/terraform-provider-heroku_freebsd_386/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_freebsd_amd64_v1/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_freebsd_arm_6/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_freebsd_arm64/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_openbsd_amd64_v1/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_openbsd_386/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_solaris_amd64_v1/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_windows_amd64_v1/terraform-provider-heroku_v5.1.0-signing-key-test.1.exe
    • building                                       binary=dist/terraform-provider-heroku_windows_386/terraform-provider-heroku_v5.1.0-signing-key-test.1.exe
    • building                                       binary=dist/terraform-provider-heroku_windows_arm_6/terraform-provider-heroku_v5.1.0-signing-key-test.1.exe
    • building                                       binary=dist/terraform-provider-heroku_windows_arm64/terraform-provider-heroku_v5.1.0-signing-key-test.1.exe
    • building                                       binary=dist/terraform-provider-heroku_linux_amd64_v1/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_linux_386/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_linux_arm_6/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_linux_arm64/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_darwin_amd64_v1/terraform-provider-heroku_v5.1.0-signing-key-test.1
    • building                                       binary=dist/terraform-provider-heroku_darwin_arm64/terraform-provider-heroku_v5.1.0-signing-key-test.1
    •took: 6m31s
  ⨯release failed after 6m37serror=failed to build for windows_arm64: exit status 2: cmd/go: unsupported GOOS/GOARCH pair windows/arm64
```