### PR TITLE
Remove erroneous "optional" because this is readonly attribute

### DIFF
--- a/heroku/resource_heroku_addon.go
+++ b/heroku/resource_heroku_addon.go
@@ -77,7 +77,6 @@ func resourceHerokuAddon() *schema.Resource {
 
 			"config_var_values": {
 				Type:     schema.TypeMap,
-				Optional: true,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type:      schema.TypeString,


### PR DESCRIPTION
While working with the provider, we realized that the read-only, computed `heroku_addon.config_var_values` is marked `optional: true`, which means Terraform will accept configuration for it.

This changeset removes the `config_var_values` attribute's optional write-ability, which will cause configurations that may have set this (with no effect) to throw an error for the unsettable attribute.