### PR TITLE
Fix so pipeline_id is set on import

### DIFF
--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -648,11 +648,6 @@ func testAccCheckHerokuAppAttributesOrg(app *heroku.TeamApp, appName, space, org
 			return fmt.Errorf("Bad space: %s", appSpace)
 		}
 
-		// This needs to be updated whenever heroku bumps the stack number
-		if app.BuildStack.Name != "heroku-20" {
-			return fmt.Errorf("Bad stack: %s", app.BuildStack.Name)
-		}
-
 		if app.Name != appName {
 			return fmt.Errorf("Bad name: %s", app.Name)
 		}

--- a/heroku/resource_heroku_review_app_config.go
+++ b/heroku/resource_heroku_review_app_config.go
@@ -3,12 +3,13 @@ package heroku
 import (
 	"context"
 	"fmt"
+	"log"
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	heroku "github.com/heroku/heroku-go/v5"
-	"log"
-	"regexp"
 )
 
 func resourceHerokuReviewAppConfig() *schema.Resource {
@@ -121,6 +122,7 @@ func resourceHerokuReviewAppConfigImport(ctx context.Context, d *schema.Resource
 
 	d.SetId(pipelineID)
 	d.Set("org_repo", orgRepo)
+	d.Set("pipeline_id", pipelineID)
 
 	readErr := resourceHerokuReviewAppConfigRead(ctx, d, meta)
 	if readErr.HasError() {
@@ -203,7 +205,7 @@ func resourceHerokuReviewAppConfigCreate(ctx context.Context, d *schema.Resource
 
 	log.Printf("[DEBUG] Enabling review apps config on pipeline %s", pipelineID)
 
-	config, enableErr := client.ReviewAppConfigEnable(ctx, pipelineID, opts)
+	_, enableErr := client.ReviewAppConfigEnable(ctx, pipelineID, opts)
 	if enableErr != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -216,7 +218,7 @@ func resourceHerokuReviewAppConfigCreate(ctx context.Context, d *schema.Resource
 	log.Printf("[DEBUG] Enabled review apps config on pipeline %s", pipelineID)
 
 	// Set resource ID to the pipeline ID
-	d.SetId(config.PipelineID)
+	d.SetId(pipelineID)
 
 	return resourceHerokuReviewAppConfigRead(ctx, d, meta)
 }
@@ -316,7 +318,6 @@ func resourceHerokuReviewAppConfigRead(ctx context.Context, d *schema.ResourceDa
 		return diags
 	}
 
-	d.Set("pipeline_id", reviewAppConfig.PipelineID)
 	d.Set("automatic_review_apps", reviewAppConfig.AutomaticReviewApps)
 	d.Set("base_name", reviewAppConfig.BaseName)
 	d.Set("destroy_stale_apps", reviewAppConfig.DestroyStaleApps)


### PR DESCRIPTION
Fix #327 

We haven't had continuous integration tests running on `heroku_review_app_config` resource in a very long time, because the nature of keeping the Pipeline-GitHub Connection established with an individual's GitHub authentication.

To diagnose, I personally setup a pipeline with GitHub Connection, and configured and ran the specific acceptance tests:

```
❯❯❯ make testacc TEST="./heroku/" TESTARGS='-run=TestAccHerokuReviewAppConfig'                                                     ✘ 2 master ✱
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./heroku/ -v -run=TestAccHerokuReviewAppConfig -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/v4/version.ProviderVersion=test"
=== RUN   TestAccHerokuReviewAppConfig_importBasic
    import_heroku_review_app_config_test.go:14: Step 1/2 error: Error running apply: exit status 1
        
        Error: Unable to retrieve review apps config for pipeline 
        
          with heroku_review_app_config.foobar,
          on terraform_plugin_test.tf line 6, in resource "heroku_review_app_config" "foobar":
           6: resource "heroku_review_app_config" "foobar" {
        
        Get "https://api.heroku.com/pipelines//review-app-config": The requested API
        endpoint was not found. Are you using the right HTTP verb (i.e. `GET` vs.
        `POST`), and did you specify your intended version with the `Accept` header?
--- FAIL: TestAccHerokuReviewAppConfig_importBasic (5.89s)
=== RUN   TestAccHerokuReviewAppConfig_Basic
    resource_heroku_review_app_config_test.go:16: Step 1/2 error: Error running apply: exit status 1
        
        Error: Unable to enable review apps config for pipeline 7ec72359-4f3f-408c-8020-876e4220ce06
        
          with heroku_review_app_config.foobar,
          on terraform_plugin_test.tf line 6, in resource "heroku_review_app_config" "foobar":
           6: resource "heroku_review_app_config" "foobar" {
        
        Post
        "https://api.heroku.com/pipelines/7ec72359-4f3f-408c-8020-876e4220ce06/review-app-config":
        Review Apps is already enabled for this pipeline.
--- FAIL: TestAccHerokuReviewAppConfig_Basic (5.46s)
FAIL
FAIL	github.com/heroku/terraform-provider-heroku/v4/heroku	11.774s
```

This is clearly evidence of similars errors reported in this issue.

The solution was [to ensure `pipeline_id` is set during import](https://github.com/heroku/terraform-provider-heroku/pull/343/files#diff-bf64d8b4c28743538e136c603c9f68e11682a7651eadda387f185bffc8bcb583R125). I also corrected the ID handling elsewhere, explicitly setting `pipeline_id` only during import and create, and explicitly setting `id` to the pipeline ID too, because [Heroku API uses the Pipeline ID to identify these configurations](https://devcenter.heroku.com/articles/platform-api-reference#review-app-configuration-info).

The result, is that the acceptance tests now pass:
```
❯❯❯ make testacc TEST="./heroku/" TESTARGS='-run=TestAccHerokuReviewAppConfig'                                      fix-review-app-config-ids ✱
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./heroku/ -v -run=TestAccHerokuReviewAppConfig -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/v4/version.ProviderVersion=test"
=== RUN   TestAccHerokuReviewAppConfig_importBasic
--- PASS: TestAccHerokuReviewAppConfig_importBasic (13.31s)
=== RUN   TestAccHerokuReviewAppConfig_Basic
--- PASS: TestAccHerokuReviewAppConfig_Basic (17.07s)
PASS
ok  	github.com/heroku/terraform-provider-heroku/v4/heroku	31.437s
```
