### PR TITLE
Document the format required by "headers"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -116,9 +116,9 @@ The following arguments are supported:
 * `email` - (Required) Email to be notified by Heroku. It must be provided, but
   it can also be sourced from [other locations](#Authentication).
 
-* `headers` - (Optional) Additional Headers to be sent to Heroku. If not
-  provided, it will be sourced from the `HEROKU_HEADERS` environment variable
-  (if set).
+* `headers` - (Optional) Additional Headers to be sent to Heroku, as a string-encoded JSON object, 
+  for example: `{"X-Custom-Header":"yes","X-Custom-Header-Too":"no"}`. If not provided, it will be 
+  sourced from the `HEROKU_HEADERS` environment variable (if set).
 
 * `customizations` - (Optional) Various attributes altering the behavior of certain resources.
   Only a single `customizations` block may be specified, and it supports the following arguments:


### PR DESCRIPTION
This PR simply documents what is expected for the provider's `headers` attribute.

In helping solve an internal usage question, we realized that this is only documented by [a test](https://github.com/heroku/terraform-provider-heroku/blob/v5.1.4/heroku/provider_test.go#L67).
