### PR TITLE
Upgrade module to v5

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ test: fmtcheck
 		xargs -t -n4 go test -v $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/v6/version.ProviderVersion=test"
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/v5/version.ProviderVersion=test"
 
 vet:
 	@echo "go vet ."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ test: fmtcheck
 		xargs -t -n4 go test -v $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/v4/version.ProviderVersion=test"
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=240m -ldflags="-X=github.com/heroku/terraform-provider-heroku/v6/version.ProviderVersion=test"
 
 vet:
 	@echo "go vet ."

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/heroku/terraform-provider-heroku/v4
+module github.com/heroku/terraform-provider-heroku/v6
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/heroku/terraform-provider-heroku/v6
+module github.com/heroku/terraform-provider-heroku/v5
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v6/version"
+	"github.com/heroku/terraform-provider-heroku/v5/version"
 	homedir "github.com/mitchellh/go-homedir"
 )
 

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v4/version"
+	"github.com/heroku/terraform-provider-heroku/v6/version"
 	homedir "github.com/mitchellh/go-homedir"
 )
 

--- a/heroku/helper.go
+++ b/heroku/helper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v4/version"
+	"github.com/heroku/terraform-provider-heroku/v6/version"
 )
 
 // getAppName extracts the app attribute generically from a Heroku resource.

--- a/heroku/helper.go
+++ b/heroku/helper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v6/version"
+	"github.com/heroku/terraform-provider-heroku/v5/version"
 )
 
 // getAppName extracts the app attribute generically from a Heroku resource.

--- a/heroku/provider_test.go
+++ b/heroku/provider_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	helper "github.com/heroku/terraform-provider-heroku/v6/helper/test"
+	helper "github.com/heroku/terraform-provider-heroku/v5/helper/test"
 )
 
 const (

--- a/heroku/provider_test.go
+++ b/heroku/provider_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	helper "github.com/heroku/terraform-provider-heroku/v4/helper/test"
+	helper "github.com/heroku/terraform-provider-heroku/v6/helper/test"
 )
 
 const (

--- a/heroku/resource_heroku_cert_test.go
+++ b/heroku/resource_heroku_cert_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v4/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
 )
 
 // We break apart testing for EU and US because at present, Heroku deals with

--- a/heroku/resource_heroku_cert_test.go
+++ b/heroku/resource_heroku_cert_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v5/helper/test"
 )
 
 // We break apart testing for EU and US because at present, Heroku deals with

--- a/heroku/resource_heroku_domain_test.go
+++ b/heroku/resource_heroku_domain_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v4/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
 )
 
 func TestAccHerokuDomain_Basic(t *testing.T) {

--- a/heroku/resource_heroku_domain_test.go
+++ b/heroku/resource_heroku_domain_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v5/helper/test"
 )
 
 func TestAccHerokuDomain_Basic(t *testing.T) {

--- a/heroku/resource_heroku_space_app_access_test.go
+++ b/heroku/resource_heroku_space_app_access_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/heroku/terraform-provider-heroku/v4/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/heroku/resource_heroku_space_app_access_test.go
+++ b/heroku/resource_heroku_space_app_access_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v5/helper/test"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/heroku/resource_heroku_ssl_test.go
+++ b/heroku/resource_heroku_ssl_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v5/helper/test"
 )
 
 func TestAccHerokuSSL_basic(t *testing.T) {

--- a/heroku/resource_heroku_ssl_test.go
+++ b/heroku/resource_heroku_ssl_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/heroku/terraform-provider-heroku/v4/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
 )
 
 func TestAccHerokuSSL_basic(t *testing.T) {

--- a/heroku/resource_heroku_team_collaborator_test.go
+++ b/heroku/resource_heroku_team_collaborator_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v5/helper/test"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/heroku/resource_heroku_team_collaborator_test.go
+++ b/heroku/resource_heroku_team_collaborator_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/heroku/terraform-provider-heroku/v4/helper/test"
+	"github.com/heroku/terraform-provider-heroku/v6/helper/test"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/heroku/terraform-provider-heroku/v6/heroku"
+	"github.com/heroku/terraform-provider-heroku/v5/heroku"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/heroku/terraform-provider-heroku/v4/heroku"
+	"github.com/heroku/terraform-provider-heroku/v6/heroku"
 )
 
 func main() {

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ package version
 //https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/version
 //This takes advantage of a new build flag populating the binary version of the
 //provider, for example:
-//-ldflags="-X=github.com/heroku/terraform-provider-heroku/v4/version.ProviderVersion=x.x.x"
+//-ldflags="-X=github.com/heroku/terraform-provider-heroku/v6/version.ProviderVersion=x.x.x"
 
 var (
 	// ProviderVersion is set during the release process to the release version of the binary, and

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ package version
 //https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/version
 //This takes advantage of a new build flag populating the binary version of the
 //provider, for example:
-//-ldflags="-X=github.com/heroku/terraform-provider-heroku/v6/version.ProviderVersion=x.x.x"
+//-ldflags="-X=github.com/heroku/terraform-provider-heroku/v5/version.ProviderVersion=x.x.x"
 
 var (
 	// ProviderVersion is set during the release process to the release version of the binary, and


### PR DESCRIPTION
The tagging and module version are not consistent (currently on v4 and most recent release is 5.1.5). This PR upgrades the module to v5

More context here: https://salesforce-internal.slack.com/archives/CCHLHGYN4/p1666192706879899

(For the public, this change is to resolve an error with importing this provider as a module for use within another provider.)