### PR TITLE
Changed app_id to app

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -22,7 +22,7 @@ resource "heroku_app" "default" {
 
 # Associate a custom domain
 resource "heroku_domain" "default" {
-  app_id   = heroku_app.default.id
+  app   = heroku_app.default.id
   hostname = "terraform.example.com"
 }
 ```
@@ -32,7 +32,7 @@ resource "heroku_domain" "default" {
 The following arguments are supported:
 
 * `hostname` - (Required) The hostname to serve requests from.
-* `app_id` - (Required) Heroku app ID (do not use app name)
+* `app` - (Required) Heroku app ID (do not use app name)
 
 ## Attributes Reference
 


### PR DESCRIPTION
Using app_id triggers an error doing a `terraform apply`. Changing to `app` attribute, it works.