### PR TITLE
Domain sni_endpoint_id cooperation with ACM

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -23,25 +23,29 @@ resource "heroku_app" "default" {
 # Associate a custom domain
 resource "heroku_domain" "default" {
   app_id   = heroku_app.default.id
-  hostname = "terraform.example.com"
+  hostname = "www.example.com"
 }
 ```
 
 ## Argument Reference
 
-The following arguments are supported:
-
-* `hostname` - (Required) The hostname to serve requests from.
 * `app_id` - (Required) Heroku app ID (do not use app name)
+
+For apps with ACM enabled (automated certificate management):
+
+* `hostname` - (Required) The hostname to setup via ACM.
+
+For apps with `heroku_ssl` (SNI Endpoint) resources (manual certificate management):
+
+* `hostname` - (Required) Must match common name or a subject alternative name of certificate in the `heroku_ssl` resource references by `sni_endpoint_id`.
+* `sni_endpoint_id` - (Required) The ID of the `heroku_ssl` resource to associate the domain with.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The ID of the domain record.
-* `hostname` - The hostname traffic will be served as.
 * `cname` - The CNAME traffic should route to.
-* `sni_endpoint_id` - The ID of the heroku_ssl resource to associate the domain with.
 
 ## Importing
 

--- a/heroku/resource_heroku_domain.go
+++ b/heroku/resource_heroku_domain.go
@@ -43,7 +43,6 @@ func resourceHerokuDomain() *schema.Resource {
 
 			"sni_endpoint_id": {
 				Type:     schema.TypeString,
-				Computed: true,
 				Optional: true,
 			},
 		},


### PR DESCRIPTION
`heroku_domain` `sni_endpoint_id` should not be **computed**. It should remain completely unset in Terraform for ACM-enabled apps.

`sni_endpoint_id` should only be set when the user wants to establish a manually managed certificate for a domain.

Additionally, this **optional** + **computed** attribute combination is suspected to cause drift issues; removing **computed** should fix state churn around the ACM (automated certificate management) quietly updating/changing SNI Endpoints.