### PR TITLE
Omit sensitive_config_vars values from TF_LOG=debug output

### DIFF
--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -408,12 +408,16 @@ func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	log.Printf("[LOG] Setting config vars: %s", configVars)
+	log.Printf("[DEBUG] Setting config vars: %s", configVars)
 	if err := d.Set("config_vars", configVars); err != nil {
 		log.Printf("[WARN] Error setting config vars: %s", err)
 	}
 
-	log.Printf("[LOG] Setting sensitive config vars: %s", sensitiveConfigVars)
+	var sensitiveVarNames []string
+	for sensitiveVarName, _ := range sensitiveConfigVars {
+		sensitiveVarNames = append(sensitiveVarNames, sensitiveVarName)
+	}
+	log.Printf("[DEBUG] Setting sensitive config vars: %s", sensitiveVarNames)
 	if err := d.Set("sensitive_config_vars", sensitiveConfigVars); err != nil {
 		log.Printf("[WARN] Error setting sensitive config vars: %s", err)
 	}


### PR DESCRIPTION
Discovered this disclosure vulnerability when debugging a Terraform configuration with `TF_LOG=debug`.

This changes the behavior to output just the `heroku_app` `sensitive_config_vars` names and not their values.