### PR TITLE
New Provider security option and Security Practices guide

### DIFF
--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1,0 +1,83 @@
+---
+layout: "heroku"
+page_title: "Heroku: Secure Practices"
+sidebar_current: "docs-heroku-guides-security"
+description: |-
+  Guide to using the provider securely.
+---
+
+# Authentication
+
+The API key used by Terraform must inherently have complete permission 
+to manage Heroku resources.
+
+To generate API keys with minimal scope, see 
+[Dev Center article **Using Terraform with Heroku: Authorization**](https://devcenter.heroku.com/articles/using-terraform-with-heroku#authorization).
+
+The API key can be set for the provider following the 
+[Provider Authentication docs](../#authentication).
+
+# Sensitivity
+
+Terraform includes the concept of `sensitive` values which are 
+automatically redacted from terminal output, such as plan diffs and 
+output summaries.
+
+Various resource attributes are defined in the provider as sensitive, 
+including: `heroku_app`#`all_config_vars`, 
+`heroku_addon`#`config_var_values`, & `heroku_app_webhook`#`secret`.
+
+In every configuration, practice marking `sensitive = true` variables &
+outputs that contain secret data:
+
+```hcl
+variable "heroku_api_key" {
+  type        = string
+  sensitive   = true
+}
+
+output "production_database_url" {
+  type      = string
+  value     = heroku_addon.production_postgres.config_var_values["DATABASE_URL"]
+  sensitive = true
+}
+```
+
+# Config Vars
+
+Especially sensitive Heroku app config vars may be managed from outside of 
+Terraform, set through `heroku config` CLI, web dashboard, or Platform API,
+to avoid their values touching Terraform workflows.
+
+Also, config vars automatically set by add-ons, such as Postgres 
+`DATABASE_URL`, will be recorded in Terraform state as part of the standard
+functionality of this Terraform provider.
+
+In high-security situations, these externally managed config vars can be 
+completely excluded from Terraform by setting the 
+[provider attributes](../#argument-reference):
+
+```hcl
+provider "heroku" {
+  customizations {
+    set_app_all_config_vars_in_state = false
+    set_addon_config_vars_in_state   = false
+  }
+}
+```
+
+As a result, `heroku_app`#`all_config_vars` and 
+`heroku_addon`#`config_var_values` will be empty for all resources 
+managed in Terraform.
+
+# Logging
+
+In normal runtime, the provider is designed to avoid logging sensitive data.
+
+When `TF_LOG` environment variable is set, such as `TF_LOG=debug`, the 
+provider will log extensive data including Heroku API calls. `Authorization` 
+headers are automatically redacted, but logged request and response JSON
+bodies will contain secret values, such as app config vars.
+
+Only set `TF_LOG` in environments where the sensitive log output is 
+acceptable. Destroy/delete such logs after use to avoid disclosure.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ simplest path to delivering apps quickly:
 ## Guides
 
 * [Upgrading](guides/upgrading.html)
+* [Secure Practices](guides/security.html)
 
 ## Contributing
 
@@ -63,6 +64,8 @@ All authentication tokens must be generated with one of these methods:
 * [Heroku Dashboard](https://dashboard.heroku.com) → Account Settings → Applications → [Authorizations](https://dashboard.heroku.com/account/applications)
 * `heroku auth` command of the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
 * [Heroku Platform APIs: OAuth](https://devcenter.heroku.com/articles/platform-api-reference#oauth-authorization)
+
+🔐  See [Secure Practices](guides/security.html#authentication) for help creating a safe API token.
 
 ⛔️  Direct username-password authentication is [no longer supported by Heroku API](https://devcenter.heroku.com/changelog-items/2516).
 
@@ -123,7 +126,7 @@ The directory containing the `.netrc` file can be overridden by the `NETRC` envi
 The following arguments are supported:
 
 * `api_key` - (Required) Heroku API token. It must be provided, but it can also
-  be sourced from [other locations](#Authentication).
+  be sourced from [other locations](#Authentication). See also [Secure Practices](guides/security.html).
 
 * `email` - (Ignored) This field originally supported username-password authentication, 
   but has since [been deprecated](https://devcenter.heroku.com/changelog-items/2516).
@@ -137,15 +140,16 @@ The following arguments are supported:
   Only a single `customizations` block may be specified, and it supports the following arguments:
 
   * `set_app_all_config_vars_in_state` - (Optional) Controls whether the `heroku_app.all_config_vars` attribute
-    is set in the state file. The aforementioned attribute stores a snapshot of all config vars in Terraform state,
-    even if they are not defined in Terraform. This means sensitive Heroku add-on config vars,
-    such as Postgres' `DATABASE_URL`, are always accessible in the state.
-    Set to `false` to only track managed config vars in the state. Defaults to `true`.
+    is set in the state file. Normally a snapshot of all config vars is stored in state, even though they are
+    not managed by Terraform, such as secrets set via `heroku config` CLI, web dashboard, or add-ons like 
+    Postgres' `DATABASE_URL`. Set to `false` to only track managed config vars in the state. Defaults to `true`.
+    See also [Secure Practices](guides/security.html).
 
   * `set_addon_config_vars_in_state` - (Optional) Controls whether the `heroku_addon.config_var_values` attribute
     is set in the state file. The attribute stores each addon's config vars in Terraform state. This means 
     sensitive add-on config vars, such as Postgres' `DATABASE_URL`, are always accessible in the state.
     Set to `false` to prevent capturing these values. Defaults to `true`.
+    See also [Secure Practices](guides/security.html).
 
 * `delays` - (Optional) Delays help mitigate issues that can arise due to
   Heroku's eventually consistent data model. Only a single `delays` block may be

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,6 +142,11 @@ The following arguments are supported:
     such as Postgres' `DATABASE_URL`, are always accessible in the state.
     Set to `false` to only track managed config vars in the state. Defaults to `true`.
 
+  * `set_addon_config_vars_in_state` - (Optional) Controls whether the `heroku_addon.config_var_values` attribute
+    is set in the state file. The attribute stores each addon's config vars in Terraform state. This means 
+    sensitive add-on config vars, such as Postgres' `DATABASE_URL`, are always accessible in the state.
+    Set to `false` to prevent capturing these values. Defaults to `true`.
+
 * `delays` - (Optional) Delays help mitigate issues that can arise due to
   Heroku's eventually consistent data model. Only a single `delays` block may be
   specified, and it supports the following arguments:

--- a/heroku/config.go
+++ b/heroku/config.go
@@ -25,6 +25,7 @@ const (
 
 	// Default custom timeouts
 	DefaultAddonCreateTimeout         = int64(20)
+	DefaultSetAddonConfigVarsInState  = true
 	DefaultSetAppAllConfigVarsInState = true
 )
 
@@ -45,6 +46,7 @@ type Config struct {
 	AddonCreateTimeout int64
 
 	// Customization
+	SetAddonConfigVarsInState  bool
 	SetAppAllConfigVarsInState bool
 }
 
@@ -60,6 +62,7 @@ func NewConfig() *Config {
 		PostDomainCreateDelay:      DefaultPostDomainCreateDelay,
 		PostSpaceCreateDelay:       DefaultPostSpaceCreateDelay,
 		AddonCreateTimeout:         DefaultAddonCreateTimeout,
+		SetAddonConfigVarsInState:  DefaultSetAddonConfigVarsInState,
 		SetAppAllConfigVarsInState: DefaultSetAppAllConfigVarsInState,
 	}
 	if logging.IsDebugOrHigher() {
@@ -120,6 +123,9 @@ func (c *Config) applySchema(d *schema.ResourceData) (err error) {
 			customizations := v.(map[string]interface{})
 			if v, ok := customizations["set_app_all_config_vars_in_state"].(bool); ok {
 				c.SetAppAllConfigVarsInState = v
+			}
+			if v, ok := customizations["set_addon_config_vars_in_state"].(bool); ok {
+				c.SetAddonConfigVarsInState = v
 			}
 		}
 	}

--- a/heroku/provider.go
+++ b/heroku/provider.go
@@ -38,7 +38,7 @@ func Provider() *schema.Provider {
 
 			"customizations": {
 				Type:     schema.TypeList,
-				MaxItems: 1,
+				MaxItems: 2,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -46,6 +46,11 @@ func Provider() *schema.Provider {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  DefaultSetAppAllConfigVarsInState,
+						},
+						"set_addon_config_vars_in_state": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  DefaultSetAddonConfigVarsInState,
 						},
 					},
 				},

--- a/heroku/resource_heroku_addon_test.go
+++ b/heroku/resource_heroku_addon_test.go
@@ -93,6 +93,22 @@ func TestAccHerokuAddon_ConfigVarValues(t *testing.T) {
 	})
 }
 
+func TestAccHerokuAddon_DontSetConfigVarValues(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAddonConfig_dontSetConfigVarValues(appName),
+				Check: resource.TestCheckNoResourceAttr(
+					"heroku_addon.pg", "config_var_values.DATABASE_URL"),
+			},
+		},
+	})
+}
+
 func TestAccHerokuAddon_CustomName(t *testing.T) {
 	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
@@ -302,6 +318,25 @@ resource "heroku_addon" "foobar" {
 
 func testAccCheckHerokuAddonConfig_configVarValues(appName string) string {
 	return fmt.Sprintf(`
+resource "heroku_app" "foobar" {
+    name = "%s"
+    region = "us"
+}
+
+resource "heroku_addon" "pg" {
+    app_id = heroku_app.foobar.id
+    plan = "heroku-postgresql:mini"
+}`, appName)
+}
+
+func testAccCheckHerokuAddonConfig_dontSetConfigVarValues(appName string) string {
+	return fmt.Sprintf(`
+provider "heroku" {
+  customizations {
+    set_addon_config_vars_in_state = false
+  }
+}
+
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"


### PR DESCRIPTION
Support for new provider security option:

```hcl
provider "heroku" {
   customizations {
     set_addon_config_vars_in_state   = false
   }
 }
```

…along with docs including new [Security Practices guide](https://github.com/heroku/terraform-provider-heroku/blob/config-setting-addon-var-values/docs/guides/security.md) to explain usage.