### PR TITLE
Fix build flag to set provider version for user-agent string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: pub-hk-ubuntu-22.04-small
     steps:
       - 
         name: Checkout

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     ldflags:
-        - '-s -w -X=github.com/heroku/terraform-provider-heroku/version.ProviderVersion={{.Version}}'
+        - -s -w -X github.com/heroku/terraform-provider-heroku/v5/version.ProviderVersion={{.Version}}
     goos:
       - freebsd
       - openbsd

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     ldflags:
-        - '-s -w -X version.ProviderVersion={{.Version}}'
+        - '-s -w -X=github.com/heroku/terraform-provider-heroku/version.ProviderVersion={{.Version}}'
     goos:
       - freebsd
       - openbsd


### PR DESCRIPTION
This build flag has been incorrect for years, and as a result the provider sends requests as user-agent `terraform-provider-heroku/dev` for all usage that is not [an acceptance test](https://github.com/heroku/terraform-provider-heroku/blob/master/GNUmakefile#L21), instead of with the version, such as `terraform-provider-heroku/5.1.1`.

This corrects the build flag to set the version correctly as [documented in the comments](https://github.com/heroku/terraform-provider-heroku/blob/master/version/version.go#L7).