### PR TITLE
Remove space in addon_attachment namespace example

### DIFF
--- a/docs/resources/addon_attachment.md
+++ b/docs/resources/addon_attachment.md
@@ -22,7 +22,7 @@ resource "heroku_addon_attachment" "database" {
 resource "heroku_addon_attachment" "database_credentials" {
   app_id  = heroku_app.default.id
   addon_id = heroku_addon.database.id
-  namespace = "credential: ${var.credential_name}"
+  namespace = "credential:${var.credential_name}"
 }
 
 ```


### PR DESCRIPTION
This is a typo: https://devcenter.heroku.com/articles/platform-api-reference#add-on-attachment-create-optional-parameters