### PR TITLE
Switch to new Ubuntu 24.04 custom GitHub runner group

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - 
         name: Checkout


### PR DESCRIPTION
New custom GitHub Actions runner groups have been created for Ubuntu 24.04:
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZR57becb9df8d94f80b132168fd
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

This switches to them, so we can clean up the old groups.