### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,26 +10,29 @@ jobs:
     steps:
       - 
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.2.0
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist
+          distribution: goreleaser
+          version: 'latest'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -45,4 +46,4 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
[W-19365243](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002KKLKsYAP/view) **[terraform-provider-heroku] Restore ability to manage & publish in Public Registry**

Upgrades release actions to current major versions, specifically addressing broken, old `goreleaser`.

While `goreleaser` is now working again, the attempted pre-release performed against this branch is still failing because of the expired signing key:
```
Run goreleaser/goreleaser-action@v6
 …
  • signing artifacts
    • signing                                        cmd=gpg artifact=terraform-provider-heroku_5.2.11-pre.6_SHA256SUMS signature=dist/terraform-provider-heroku_5.2.11-pre.6_SHA256SUMS.sig
sign: gpg failed: exit status 2: gpg: skipped "8D1B9B2A51A6B97B3128874E5F762A83995454B3": Unusable secret key
gpg: signing failed: Unusable secret key
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.11.2/x64/goreleaser' failed with exit code 1
```