### PR TITLE
Honor whatever the `space` attribute is set as, ID/UUID or name.

### DIFF
--- a/docs/resources/space_app_access.md
+++ b/docs/resources/space_app_access.md
@@ -41,7 +41,7 @@ resource "heroku_space_app_access" "member2" {
 
 The following arguments are supported:
 
-* `space` - (Required) The ID of the Private Space.
+* `space` - (Required) The name of the Private Space (ID/UUID is acceptable too, but must be used consistently).
 * `email` - (Required) The email of the existing Heroku Team member.
 * `permissions` - (Required) The permissions to grant the team member for the Private Space.
   Currently `create_apps` is the only supported permission. If not provided the member will have no permissions to the space.

--- a/docs/resources/space_app_access.md
+++ b/docs/resources/space_app_access.md
@@ -24,14 +24,14 @@ resource "heroku_space" "default" {
 
 // Give an existing team member create_apps permissions to the Private Space
 resource "heroku_space_app_access" "member1" {
-  space = heroku_space.default.id
+  space = heroku_space.default.name
   email = "member1@example.com"
   permissions = ["create_apps"]
 }
 
 // Remove all permissions from an existing team member
 resource "heroku_space_app_access" "member2" {
-  space = heroku_space.default.id
+  space = heroku_space.default.name
   email = "member2@example.com"
   permissions = []
 }

--- a/docs/resources/space_inbound_ruleset.md
+++ b/docs/resources/space_inbound_ruleset.md
@@ -42,7 +42,7 @@ resource "heroku_space_inbound_ruleset" "default" {
 
 The following arguments are supported:
 
-* `space` - (Required) The ID of the space.
+* `space` - (Required) The name of the Private Space (ID/UUID is acceptable too, but must be used consistently).
 * `rule` - (Required) At least one `rule` block. Rules are documented below.
 
 A `rule` block supports the following arguments:

--- a/docs/resources/space_inbound_ruleset.md
+++ b/docs/resources/space_inbound_ruleset.md
@@ -24,7 +24,7 @@ resource "heroku_space" "default" {
 
 # Allow all traffic EXCEPT 8.8.4.4 to access the HPS.
 resource "heroku_space_inbound_ruleset" "default" {
-  space = heroku_space.default.id
+  space = heroku_space.default.name
 
   rule {
     action = "allow"

--- a/docs/resources/space_peering_connection_accepter.md
+++ b/docs/resources/space_peering_connection_accepter.md
@@ -36,7 +36,7 @@ resource "heroku_space_peering_connection_accepter" "accept" {
 
 The following arguments are supported:
 
-* `space` - (Required) The ID of the space.
+* `space` - (Required) The name of the Private Space (ID/UUID is acceptable too, but must be used consistently).
 * `vpc_peering_connection_id` - (Required) The peering connection request ID.
 
 ## Attributes Reference

--- a/docs/resources/space_peering_connection_accepter.md
+++ b/docs/resources/space_peering_connection_accepter.md
@@ -27,7 +27,7 @@ resource "aws_vpc_peering_connection" "request" {
 
 # Accept the request.
 resource "heroku_space_peering_connection_accepter" "accept" {
-  space                     = heroku_space.peer_space.id
+  space                     = heroku_space.peer_space.name
   vpc_peering_connection_id = aws_vpc_peering_connection.request.id
 }
 ```

--- a/docs/resources/space_vpn_connection.md
+++ b/docs/resources/space_vpn_connection.md
@@ -34,7 +34,7 @@ resource "heroku_space_vpn_connection" "office" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the VPN connection.
-* `space` - (Required) The ID of the Heroku Private Space where the VPN connection will be established.
+* `space` - (Required) The name of the Private Space (ID/UUID is acceptable too, but must be used consistently).
 * `public_ip` - (Required) The public IP address of the VPN endpoint on the network where the VPN connection will be established.
 * `routable_cidrs` - (Required) A list of IPv4 CIDR blocks used by the network where the VPN connection will be established.
 

--- a/docs/resources/space_vpn_connection.md
+++ b/docs/resources/space_vpn_connection.md
@@ -23,7 +23,7 @@ resource "heroku_space" "default" {
 // Connect the Heroku space to another network with a VPN
 resource "heroku_space_vpn_connection" "office" {
   name           = "office"
-  space          = heroku_space.default.id
+  space          = heroku_space.default.name
   public_ip      = "203.0.113.1"
   routable_cidrs = ["192.168.1.0/24"]
 }

--- a/heroku/resource_heroku_space_app_access.go
+++ b/heroku/resource_heroku_space_app_access.go
@@ -76,7 +76,6 @@ func resourceHerokuSpaceAppAccessRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 	d.SetId(spaceAppAccess.User.ID)
-	d.Set("space", spaceAppAccess.Space.Name)
 	d.Set("email", spaceAppAccess.User.Email)
 	d.Set("permissions", createPermissionsList(spaceAppAccess))
 	return nil

--- a/heroku/resource_heroku_space_inbound_ruleset.go
+++ b/heroku/resource_heroku_space_inbound_ruleset.go
@@ -101,7 +101,6 @@ func resourceHerokuSpaceInboundRulesetRead(d *schema.ResourceData, meta interfac
 
 	d.SetId(ruleset.ID)
 	d.Set("rule", rulesList)
-	d.Set("space", ruleset.Space.Name)
 
 	return nil
 }


### PR DESCRIPTION
Fix for issue where setting Space references as an ID/UUID will cause churn in the config, triggering recreation of susceptible resources on every apply.

Changes `heroku_space_inbound_ruleset` and `heroku_space_app_access` to honor whatever `space` identifier is set by the configuration, either ID/UUID or name, instead of resetting it back to name.