### PR TITLE
Add Fir generation validation for `heroku_build` resource

### DIFF
--- a/heroku/resource_heroku_build_test.go
+++ b/heroku/resource_heroku_build_test.go
@@ -530,17 +530,17 @@ func testStep_AccHerokuBuild_Generation_FirValid(spaceConfig, spaceName string) 
 		Config: fmt.Sprintf(`
 %s
 
-resource "heroku_app" "fir_build_app" {
-  name   = "tftest-fir-build-%s"
+resource "heroku_app" "fir_build_app_valid" {
+  name   = "tftest-fir-bld-v-%s"
   region = heroku_space.foobar.region
-  space  = heroku_space.foobar.id
+  space  = heroku_space.foobar.name
   organization {
     name = heroku_space.foobar.organization
   }
 }
 
 resource "heroku_build" "fir_build_valid" {
-  app_id = heroku_app.fir_build_app.id
+  app_id = heroku_app.fir_build_app_valid.id
   # No buildpacks - should work with CNB
 
   source {
@@ -549,7 +549,7 @@ resource "heroku_build" "fir_build_valid" {
 }
 `, spaceConfig, acctest.RandString(6)),
 		Check: resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("heroku_app.fir_build_app", "generation", "fir"),
+			resource.TestCheckResourceAttr("heroku_app.fir_build_app_valid", "generation", "fir"),
 			resource.TestCheckResourceAttr("heroku_build.fir_build_valid", "status", "succeeded"),
 		),
 	}
@@ -561,26 +561,17 @@ func testStep_AccHerokuBuild_Generation_FirInvalid(spaceConfig, spaceName string
 		Config: fmt.Sprintf(`
 %s
 
-resource "heroku_app" "fir_build_app" {
-  name   = "tftest-fir-build-%s"
+resource "heroku_app" "fir_build_app_invalid" {
+  name   = "tftest-fir-bld-i-%s"
   region = heroku_space.foobar.region
-  space  = heroku_space.foobar.id
+  space  = heroku_space.foobar.name
   organization {
     name = heroku_space.foobar.organization
   }
 }
 
-resource "heroku_build" "fir_build_valid" {
-  app_id = heroku_app.fir_build_app.id
-  # No buildpacks - should work with CNB
-
-  source {
-    path = "test-fixtures/app"
-  }
-}
-
 resource "heroku_build" "fir_build_invalid" {
-  app_id     = heroku_app.fir_build_app.id
+  app_id     = heroku_app.fir_build_app_invalid.id
   buildpacks = ["heroku/nodejs"]  # Should fail
 
   source {

--- a/heroku/resource_heroku_space_test.go
+++ b/heroku/resource_heroku_space_test.go
@@ -86,6 +86,10 @@ func TestAccHerokuSpace_Fir(t *testing.T) {
 			},
 			// Step 2: Test Fir app generation behavior
 			testStep_AccHerokuApp_Generation_Fir(t, spaceConfig, spaceName),
+			// Step 3: Test Fir build generation behavior (valid build)
+			testStep_AccHerokuBuild_Generation_FirValid(spaceConfig, spaceName),
+			// Step 4: Test Fir build generation behavior (invalid build with buildpacks)
+			testStep_AccHerokuBuild_Generation_FirInvalid(spaceConfig, spaceName),
 		},
 	})
 }


### PR DESCRIPTION
## Description
**Work Item**: [W-19048403](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002IBnH7YAL/view) [terraform-provider-heroku] Fir Compatibility: Builds

This PR implements Fir generation validation for the `heroku_build` resource, preventing incompatible buildpack configurations for Fir apps while maintaining full backward compatibility with traditional Cedar buildpack workflows.

### Key Features
- **Build validation**: Automatic blocking of buildpacks for Fir generation apps
- **CNB compatibility**: Clear guidance directing users to Cloud Native Buildpacks via project.toml
- **Plan & apply validation**: Two-layer validation for comprehensive error handling
- **Consistent UX**: Aligns with Heroku CLI behavior preventing silent API failures

## Changes
### Feature Matrix Enhancement
- Add build-specific features to generation matrix (`buildpacks` vs `cloud_native_buildpacks`)
- Cedar generation: Supports traditional buildpack URLs and configurations
- Fir generation: Blocks traditional buildpacks, supports Cloud Native Buildpacks via project.toml

### Build Resource Validation
- Add plan-time validation with dependency-aware logic in CustomizeDiff
- Add apply-time validation preventing misleading API "success"
- Implement comprehensive error handling with actionable user guidance
- Add acceptance tests with real API validation (2 test scenarios)
- Update documentation with generation examples and CNB migration guidance

### Usage Examples

```hcl
# Cedar generation - traditional buildpacks (works as before)
resource "heroku_build" "cedar_build" {
  app_id     = heroku_app.cedar_app.id
  buildpacks = ["heroku/nodejs", "heroku/procfile"]
  
  source {
    path = "path/to/source"
  }
}

# Fir generation - Cloud Native Buildpacks only
resource "heroku_build" "fir_build" {
  app_id = heroku_app.fir_app.id  # App in Fir space
  # No buildpacks - configured via project.toml in source
  
  source {
    path = "path/to/cnb/source"  # Contains project.toml
  }
}

# This will FAIL with clear error:
resource "heroku_build" "invalid" {
  app_id     = heroku_app.fir_app.id
  buildpacks = ["heroku/nodejs"]  # ❌ Error at apply time
  
  source {
    path = "path/to/source"
  }
}
```

### Error Handling
Apply-time validation prevents invalid configurations:
"Error: buildpacks cannot be specified for fir generation apps. Use project.toml to configure Cloud Native Buildpacks instead. See: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app"

### Test Coverage
- **Comprehensive unit tests** for feature matrix validation (4 test cases)
- **Acceptance test scenarios** with real API validation:
  - Cedar build with buildpacks (success)
  - Fir build without buildpacks (success)
  - Fir build with buildpacks (apply-time error)
- **Manual validation** confirmed end-to-end error handling

### Documentation Updates
- **Generation compatibility** section with Cedar vs Fir comparison
- **Cloud Native Buildpacks** guidance with project.toml examples
- **Updated examples** showing both Cedar and Fir generation usage
- **Clear migration path** from traditional buildpacks to CNB

### Technical Implementation
- **DRY validation logic**: Shared helper functions for consistent behavior
- **Two-layer validation**: Plan-time (when possible) + apply-time (guaranteed)
- **Dependency handling**: Graceful plan-time behavior when app doesn't exist yet
- **API behavior fix**: Prevents misleading "success" when buildpacks are silently ignored

---
**Breaking Changes**: None  
**Backward Compatible**: Yes (no generation field added to build resource)  
**Foundation**: Extends existing feature matrix framework from previous fir compatibility PRs  
**Dependencies**: Requires feature matrix foundation and app generation detection from previous PRs