### PR TITLE
Add Generation to App Data Source resource

### DIFF
--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -10,14 +10,23 @@ description: |-
 
 Use this data source to get information about a Heroku app.
 
-~> **NOTE:** This resource is only supported for apps that use [classic buildpacks](https://devcenter.heroku.com/articles/buildpacks#classic-buildpacks).
+This data source supports both the [Cedar and Fir generations](https://devcenter.heroku.com/articles/generations) of Heroku apps.
 
 ## Example Usage
 
 ```hcl-terraform
 # Lookup an existing Heroku app
 data "heroku_app" "default" {
-  name   = "my-cool-app"
+  name = "my-cool-app"
+}
+
+# Example: Check app generation and buildpacks
+output "app_generation" {
+  value = data.heroku_app.default.generation
+}
+
+output "app_buildpacks" {
+  value = data.heroku_app.default.buildpacks
 }
 ```
 
@@ -39,7 +48,9 @@ The following attributes are exported:
 
 * `stack`: The application [stack](https://devcenter.heroku.com/articles/stack) is what platform to run the application in.
 
-* `buildpacks`: A list of buildpacks that this app uses.
+* `generation`: The generation of the app platform (`cedar` or `fir`).
+
+* `buildpacks`: The list of buildpacks that this app uses. Empty for apps using Cloud Native Buildpacks, such as Fir-generation apps, which list buildpacks in `project.toml` instead.
 
 * `space`: The [space](https://devcenter.heroku.com/articles/private-spaces) in which the app runs. Not present for [Common Runtime](https://devcenter.heroku.com/articles/dyno-runtime#common-runtime) apps.
 

--- a/heroku/data_source_heroku_app.go
+++ b/heroku/data_source_heroku_app.go
@@ -35,6 +35,12 @@ func dataSourceHerokuApp() *schema.Resource {
 				Default:  nil,
 			},
 
+			"generation": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Generation of the app platform (cedar or fir)",
+			},
+
 			"internal_routing": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -139,6 +145,7 @@ func dataSourceHerokuAppRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("buildpacks", app.Buildpacks)
 	d.Set("config_vars", app.Vars)
+	d.Set("generation", app.Generation)
 
 	releaseRange := heroku.ListRange{
 		Field:      "version",
@@ -147,7 +154,7 @@ func dataSourceHerokuAppRead(d *schema.ResourceData, m interface{}) error {
 	}
 	releases, err := client.ReleaseList(context.Background(), app.App.ID, &releaseRange)
 	if err != nil {
-		return fmt.Errorf("Failed to fetch releases for app '%s': %s", name, err)
+		return fmt.Errorf("failed to fetch releases for app '%s': %s", name, err)
 	}
 	for _, r := range releases {
 		if r.Status == "succeeded" {

--- a/heroku/resource_heroku_space_test.go
+++ b/heroku/resource_heroku_space_test.go
@@ -88,7 +88,9 @@ func TestAccHerokuSpace_Fir(t *testing.T) {
 			testStep_AccHerokuApp_Generation_Fir(t, spaceConfig, spaceName),
 			// Step 3: Test Fir build generation behavior (valid build)
 			testStep_AccHerokuBuild_Generation_FirValid(spaceConfig, spaceName),
-			// Step 4: Test Fir telemetry drain functionality
+			// Step 4: Test Fir app data source functionality
+			testStep_AccDatasourceHerokuApp_Generation_Fir(t, spaceConfig, spaceName),
+			// Step 5: Test Fir telemetry drain functionality
 			testStep_AccHerokuTelemetryDrain_Generation_Fir(t, spaceConfig, spaceName),
 		},
 	})


### PR DESCRIPTION
## Add Fir generation support to heroku_app data source

### Summary
Resolves [W-19773193](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002MZyZAYA1/view) - Add Fir generation support to the `heroku_app` data source. The data source can now successfully query both Cedar and Fir generation apps, with proper generation detection and buildpack handling.

### Problem
The `heroku_app` data source was missing the `generation` field in its schema and documentation incorrectly stated it only supported "classic buildpacks" apps. While the underlying logic already worked with Fir apps (via shared `resourceHerokuAppRetrieve` function), users couldn't see the generation type and documentation suggested incompatibility.

### Solution
- **Add `generation` field** to data source schema as computed attribute
- **Expose generation in read function** with `d.Set("generation", app.Generation)`
- **Update documentation** to reflect support for both Cedar and Fir generations
- **Add comprehensive test coverage** for both generation types

### Changes
- `heroku/data_source_heroku_app.go`: Add generation field to schema and read function
- `heroku/data_source_heroku_app_test.go`: Add generation validation and Fir app test step
- `heroku/resource_heroku_space_test.go`: Integrate Fir data source test into shared space pattern
- `docs/data-sources/app.md`: Remove classic buildpack limitation, add generation documentation

### Testing
- ✅ **End-to-end API validation**: Created real Fir app and confirmed data source reads correctly
- ✅ **Generation detection**: Returns `"fir"` for Fir apps, `"cedar"` for Cedar apps  
- ✅ **Buildpack handling**: Returns empty array for Fir apps (correct behavior)
- ✅ **Backward compatibility**: All existing Cedar functionality preserved
- ✅ **Test coverage**: Added to shared `TestAccHerokuSpace_Fir` pattern

### Impact
Users can now:
```hcl
data "heroku_app" "my_app" {
  name = "my-fir-app"
}

output "generation" {
  value = data.heroku_app.my_app.generation  # "fir"
}

output "buildpacks" {  
  value = data.heroku_app.my_app.buildpacks  # []
}
```
```