### PR TITLE
Enable Fir compatibility for review app config

### DIFF
--- a/docs/resources/review_app_config.md
+++ b/docs/resources/review_app_config.md
@@ -14,7 +14,7 @@ You can only use this resource after you create a pipeline and connect it to a G
 Refer to [the Heroku Dev Center](https://devcenter.heroku.com/articles/github-integration-review-apps#setup)
 for more information.
 
--> **Note:** This resource is only supported for the [Cedar-generation](https://devcenter.heroku.com/articles/generations#cedar) apps.
+-> **Note:** This resource supports both Cedar and Fir generation pipelines.
 
 ## Example Usage
 


### PR DESCRIPTION
## Summary
Resolves [W-19773214](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002MaCDaYAN/view) - Removes artificial Cedar-only restriction from `heroku_review_app_config` resource, enabling `base_name` functionality for both Cedar and Fir generation pipelines.

## Changes
- **Documentation**: Updated to reflect support for both Cedar and Fir generations
- **Bug Fix**: Removed duplicate `base_name` assignment in create function
- **UX Enhancement**: Added helpful error message when pipeline isn't connected to GitHub

## Testing
- Confirmed API accepts `base_name` for both Cedar and Fir pipelines
- Verified improved error messaging guides users to connect pipeline to GitHub
- No generation-specific restrictions found in Heroku API

## Impact
- Enables consistent review app naming across both platform generations
- Improves user experience with actionable error messages
- Supports migration from Cedar to Fir without losing functionality