### PR TITLE
Add generation attribute to heroku_space data source

### DIFF
--- a/docs/data-sources/space.md
+++ b/docs/data-sources/space.md
@@ -42,7 +42,7 @@ The following attributes are exported:
 * `shield` - Whether or not the space has [Shield](https://devcenter.heroku.com/articles/private-spaces#shield-private-spaces) turned on. One of `on` or `off`.
 * `generation` - The generation of the space platform (`cedar` or `fir`).
 * `organization` - The Heroku Team that owns this space. The fields for this block are documented below.
-* `cidr` - The RFC-1918 CIDR the Private Space will use. It must be a /16 in 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16
+* `cidr` - The RFC-1918 CIDR block that the space uses.
 * `data_cidr` - The RFC-1918 CIDR block that the space uses for the Heroku-managed peering connection for Heroku Data add-ons.
 * `outbound_ips` - The space's stable outbound [NAT IPs](https://devcenter.heroku.com/articles/platform-api-reference#space-network-address-translation).
 

--- a/docs/data-sources/space.md
+++ b/docs/data-sources/space.md
@@ -43,7 +43,7 @@ The following attributes are exported:
 * `generation` - The generation of the space platform (`cedar` or `fir`).
 * `organization` - The Heroku Team that owns this space. The fields for this block are documented below.
 * `cidr` - The RFC-1918 CIDR the Private Space will use. It must be a /16 in 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16
-* `data_cidr` - The RFC-1918 CIDR that the Private Space will use for the Heroku-managed peering connection that's automatically created when using Heroku Data add-ons. It must be between a /16 and a /20
+* `data_cidr` - The RFC-1918 CIDR block that the space uses for the Heroku-managed peering connection for Heroku Data add-ons.
 * `outbound_ips` - The space's stable outbound [NAT IPs](https://devcenter.heroku.com/articles/platform-api-reference#space-network-address-translation).
 
 The `organization` block supports:

--- a/docs/data-sources/space.md
+++ b/docs/data-sources/space.md
@@ -15,7 +15,12 @@ Use this data source to get information about a [Heroku Private Space](https://w
 ```hcl-terraform
 # Look up a Heroku Private Space
 data "heroku_space" "default" {
-  name   = "my-secret-space"
+  name = "my-secret-space"
+}
+
+# Example: Check space generation
+output "space_generation" {
+  value = data.heroku_space.default.generation
 }
 ```
 
@@ -35,9 +40,10 @@ The following attributes are exported:
 * `region` - The region in which the Heroku Private Space is deployed.
 * `state` - The state of the Heroku Private Space. Either `allocating` or `allocated`.
 * `shield` - Whether or not the space has [Shield](https://devcenter.heroku.com/articles/private-spaces#shield-private-spaces) turned on. One of `on` or `off`.
+* `generation` - The generation of the space platform (`cedar` or `fir`).
 * `organization` - The Heroku Team that owns this space. The fields for this block are documented below.
 * `cidr` - The RFC-1918 CIDR the Private Space will use. It must be a /16 in 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16
-* `data_cidr` - The RFC-1918 CIDR that the Private Space will use for the Heroku-managed peering connection that’s automatically created when using Heroku Data add-ons. It must be between a /16 and a /20
+* `data_cidr` - The RFC-1918 CIDR that the Private Space will use for the Heroku-managed peering connection that's automatically created when using Heroku Data add-ons. It must be between a /16 and a /20
 * `outbound_ips` - The space's stable outbound [NAT IPs](https://devcenter.heroku.com/articles/platform-api-reference#space-network-address-translation).
 
 The `organization` block supports:

--- a/heroku/data_source_heroku_space.go
+++ b/heroku/data_source_heroku_space.go
@@ -61,6 +61,12 @@ func dataSourceHerokuSpace() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+
+			"generation": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Generation of the space platform (cedar or fir)",
+			},
 		},
 	}
 }

--- a/heroku/data_source_heroku_space_test.go
+++ b/heroku/data_source_heroku_space_test.go
@@ -19,6 +19,8 @@ func testStep_AccDatasourceHerokuSpace_Basic(t *testing.T, spaceConfig string) r
 				"data.heroku_space.foobar", "organization", orgName),
 			resource.TestCheckResourceAttr(
 				"data.heroku_space.foobar", "region", "virginia"),
+			resource.TestCheckResourceAttr(
+				"data.heroku_space.foobar", "generation", "cedar"),
 		),
 	}
 }
@@ -32,4 +34,28 @@ data "heroku_space" "foobar" {
   name = heroku_space.foobar.name
 }
 `, spaceConfig)
+}
+
+// testStep_AccDatasourceHerokuSpace_Generation_Fir tests the space data source with a Fir space
+func testStep_AccDatasourceHerokuSpace_Generation_Fir(t *testing.T, spaceConfig string) resource.TestStep {
+	orgName := testAccConfig.GetAnyOrganizationOrSkip(t)
+
+	config := fmt.Sprintf(`%s
+
+data "heroku_space" "data_source_test" {
+  name = heroku_space.foobar.name
+}`, spaceConfig)
+
+	return resource.TestStep{
+		Config: config,
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet("data.heroku_space.data_source_test", "name"),
+			resource.TestCheckResourceAttr("data.heroku_space.data_source_test", "generation", "fir"),
+			resource.TestCheckResourceAttr("data.heroku_space.data_source_test", "organization", orgName),
+			resource.TestCheckResourceAttr("data.heroku_space.data_source_test", "shield", "false"),
+			resource.TestCheckResourceAttrSet("data.heroku_space.data_source_test", "id"),
+			resource.TestCheckResourceAttrSet("data.heroku_space.data_source_test", "uuid"),
+			resource.TestCheckResourceAttrSet("data.heroku_space.data_source_test", "region"),
+		),
+	}
 }

--- a/heroku/resource_heroku_space.go
+++ b/heroku/resource_heroku_space.go
@@ -169,6 +169,7 @@ func resourceHerokuSpaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("shield", space.Shield)
 	d.Set("cidr", space.CIDR)
 	d.Set("data_cidr", space.DataCIDR)
+	d.Set("generation", space.Generation.Name)
 
 	// Validate generation features during plan phase (warn only)
 	generation := d.Get("generation")

--- a/heroku/resource_heroku_space_test.go
+++ b/heroku/resource_heroku_space_test.go
@@ -90,7 +90,9 @@ func TestAccHerokuSpace_Fir(t *testing.T) {
 			testStep_AccHerokuBuild_Generation_FirValid(spaceConfig, spaceName),
 			// Step 4: Test Fir app data source functionality
 			testStep_AccDatasourceHerokuApp_Generation_Fir(t, spaceConfig, spaceName),
-			// Step 5: Test Fir telemetry drain functionality
+			// Step 5: Test Fir space data source functionality
+			testStep_AccDatasourceHerokuSpace_Generation_Fir(t, spaceConfig),
+			// Step 6: Test Fir telemetry drain functionality
 			testStep_AccHerokuTelemetryDrain_Generation_Fir(t, spaceConfig, spaceName),
 		},
 	})


### PR DESCRIPTION
## Summary
Resolves [W-19794370](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002MggaFYAR/view) - Adds the missing `generation` attribute to the `heroku_space` data source, enabling it to query both Cedar and Fir generation spaces as requested.

## Changes
- **Data Source Schema**: Added `generation` field to `heroku_space` data source
- **API Integration**: Fixed space resource to read `generation` from API (`space.Generation.Name`)
- **Documentation**: Updated with generation attribute description and usage example
- **Testing**: Added comprehensive acceptance tests for both Cedar and Fir spaces

## Testing
- ✅ **Real API validation**: Tested with actual Cedar (`tftest1-naybcjqqgj`) and Fir (`tf-fir-review-e2e-001`) spaces
- ✅ **Acceptance tests**: Added `testStep_AccDatasourceHerokuSpace_Generation_Fir` and updated Cedar test
- ✅ **Integration**: Added space data source test to existing Fir test suite
- ✅ **Code quality**: Passed gofmt, go vet, and builds successfully

## Deliverables Met
- ✅ heroku_space data source can query a Fir space
- ✅ heroku_space data source includes "generation" attribute

## API Response Validation
Confirmed the generation field is correctly populated:
- Cedar spaces return `"generation": "cedar"`
- Fir spaces return `"generation": "fir"`