### PR TITLE
Add CNB support for Cedar-generation apps

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -36,6 +36,22 @@ resource "heroku_app" "cedar_app" {
 }
 ```
 
+### Cedar Generation Using Cloud Native Buildpacks
+```hcl-terraform
+resource "heroku_app" "cedar_cnb_app" {
+  name   = "my-cedar-cnb-app"
+  region = "us"
+
+  # Setting stack = "cnb" opts this Cedar app into Cloud Native Buildpacks.
+  # Do not specify buildpacks — configure them via project.toml instead.
+  stack = "cnb"
+
+  config_vars = {
+    FOOBAR = "baz"
+  }
+}
+```
+
 ### Fir Generation Using Cloud Native Buildpacks (via Fir Space)
 ```hcl-terraform
 # Create a Fir-generation space first
@@ -89,9 +105,9 @@ The resource supports the following arguments:
 * `generation`: (Computed) Generation of the app platform. Automatically determined based on the space the app is deployed to. Apps in Fir-generation spaces are `fir`, all other apps are `cedar`.
    - `cedar`: Legacy platform supporting classic buildpacks, stack configuration, and internal routing.
    - `fir`: Next-generation platform with Cloud Native Buildpacks (CNB). No support for `buildpacks`, `stack`, or `internal_routing` fields.
-* `stack`: (Optional) The name of the [stack](https://devcenter.heroku.com/articles/stack) to run the application in. **Note**: Not supported for `fir` generation apps.
+* `stack`: (Optional) The name of the [stack](https://devcenter.heroku.com/articles/stack) to run the application in. **Note**: Not supported for `fir` generation apps. Set to `"cnb"` on Cedar apps to opt into Cloud Native Buildpacks.
 * `buildpacks`: (Optional) Classic buildpack names or URLs for the application.
-  Buildpacks configured externally won't be altered if this isn't present. **Note**: Not supported for apps using Cloud Native Buildpacks, like Fir-generation apps. Use `project.toml` for configuration instead.
+  Buildpacks configured externally won't be altered if this isn't present. **Note**: Not supported for apps using Cloud Native Buildpacks (`fir` generation apps, or Cedar apps with `stack = "cnb"`). Use `project.toml` for configuration instead.
 * `config_vars`<sup>[1](#deleting-vars)</sup>: (Optional) Configuration variables for the application.
      The config variables in this map aren't the final set of configuration
      variables, but rather variables you want present. Terraform doesn't remove configuration variables set externally
@@ -151,7 +167,11 @@ The following attributes are exported:
 
 ## Cloud Native Buildpacks
 
-When apps are deployed to Fir-generation spaces, they automatically use Cloud Native Buildpacks (CNB) instead of classic Heroku buildpacks. CNBs require different configuration approaches:
+Apps use Cloud Native Buildpacks (CNB) in two cases:
+- **Fir generation**: All Fir apps use CNB automatically.
+- **Cedar generation with `stack = "cnb"`**: Cedar apps can opt into CNB by setting `stack = "cnb"`.
+
+In both cases, CNBs require different configuration approaches from classic buildpacks:
 
 ### project.toml Configuration
 

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -46,7 +46,7 @@ resource "heroku_app" "cedar_cnb_app" {
   region = "us"
 
   # Setting stack = "cnb" opts this Cedar app into Cloud Native Buildpacks.
-  # Do not specify buildpacks — configure them via project.toml instead.
+  # Instead of setting the `buildpacks` attribute, configure buildpacks with `project.toml` file.
   stack = "cnb"
 
   config_vars = {

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -37,6 +37,9 @@ resource "heroku_app" "cedar_app" {
 ```
 
 ### Cedar Generation Using Cloud Native Buildpacks
+
+For apps on CNB stack, their buildpacks are configured in the app's source code, instead of through the Heroku API. See [project.toml Configuration](#project-toml-configuration).
+
 ```hcl-terraform
 resource "heroku_app" "cedar_cnb_app" {
   name   = "my-cedar-cnb-app"

--- a/heroku/heroku_supported_features.go
+++ b/heroku/heroku_supported_features.go
@@ -25,7 +25,7 @@ var featureMatrix = map[string]map[string]map[string]bool{
 			"buildpacks":              true,  // Cedar supports traditional buildpacks
 			"stack":                   true,  // Cedar supports stack configuration
 			"internal_routing":        true,  // Cedar supports internal routing
-			"cloud_native_buildpacks": false, // Cedar doesn't use CNB by default
+			"cloud_native_buildpacks": true,  // Cedar supports CNB via stack = "cnb"
 			"otel":                    false, // Cedar doesn't supports OTel at the app level
 		},
 		"drain": {
@@ -63,6 +63,12 @@ var featureMatrix = map[string]map[string]map[string]bool{
 			"base_name": false, // Fir pipelines don't support Predictable URLs for Review Apps
 		},
 	},
+}
+
+// IsCNBApp reports whether an app is using Cloud Native Buildpacks.
+// Fir apps always use CNB. Cedar apps use CNB when stack is "cnb".
+func IsCNBApp(generation, stack string) bool {
+	return generation == "fir" || (generation == "cedar" && stack == "cnb")
 }
 
 // IsFeatureSupported checks if a feature is supported for a given generation and resource type.

--- a/heroku/heroku_supported_features_test.go
+++ b/heroku/heroku_supported_features_test.go
@@ -98,11 +98,11 @@ func TestIsFeatureSupported(t *testing.T) {
 			expected:     true,
 		},
 		{
-			name:         "Cedar app cloud_native_buildpacks should be unsupported",
+			name:         "Cedar app cloud_native_buildpacks should be supported",
 			generation:   "cedar",
 			resourceType: "app",
 			feature:      "cloud_native_buildpacks",
-			expected:     false,
+			expected:     true,
 		},
 		{
 			name:         "Fir app buildpacks should be unsupported",
@@ -224,5 +224,31 @@ func TestFeatureMatrixConsistency(t *testing.T) {
 	}
 	if IsFeatureSupported("fir", "space", "shield") {
 		t.Error("Fir space shield must be unsupported")
+	}
+}
+
+func TestIsCNBApp(t *testing.T) {
+	tests := []struct {
+		name       string
+		generation string
+		stack      string
+		expected   bool
+	}{
+		{"fir app is always CNB", "fir", "cnb", true},
+		{"fir app with empty stack is CNB", "fir", "", true},
+		{"fir app with other stack is CNB", "fir", "heroku-22", true},
+		{"cedar app with cnb stack is CNB", "cedar", "cnb", true},
+		{"cedar app with heroku-22 stack is not CNB", "cedar", "heroku-22", false},
+		{"cedar app with empty stack is not CNB", "cedar", "", false},
+		{"unknown generation is not CNB", "unknown", "cnb", false},
+		{"empty generation is not CNB", "", "cnb", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsCNBApp(tt.generation, tt.stack)
+			if got != tt.expected {
+				t.Errorf("IsCNBApp(%q, %q) = %v, want %v", tt.generation, tt.stack, got, tt.expected)
+			}
+		})
 	}
 }

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -668,15 +668,15 @@ func (a *application) Update() error {
 	var errs []error
 	var err error
 
-	// Only retrieve buildpacks for apps that support traditional buildpacks
-	if IsFeatureSupported(a.Generation, "app", "buildpacks") {
+	// Only retrieve buildpacks for apps using traditional buildpacks.
+	// Cedar apps with stack = "cnb" and all fir apps use CNB instead.
+	if IsFeatureSupported(a.Generation, "app", "buildpacks") && !IsCNBApp(a.Generation, a.App.Stack) {
 		a.Buildpacks, err = retrieveBuildpacks(a.Id, a.Client)
 		if err != nil {
 			errs = append(errs, err)
 		}
 	} else {
-		// CNB apps don't have traditional buildpacks
-		log.Printf("[DEBUG] App %s uses generation %s which doesn't support traditional buildpacks", a.Id, a.Generation)
+		log.Printf("[DEBUG] App %s (generation=%s stack=%s) uses CNB; skipping traditional buildpack retrieval", a.Id, a.Generation, a.App.Stack)
 		a.Buildpacks = []string{}
 	}
 
@@ -710,16 +710,6 @@ func retrieveBuildpacks(id string, client *heroku.Service) ([]string, error) {
 	}
 
 	return buildpacks, nil
-}
-
-// isCNBError checks if an error is related to Cloud Native Buildpacks
-func isCNBError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errorMessage := err.Error()
-	return strings.Contains(errorMessage, "Cloud Native Buildpacks") ||
-		strings.Contains(errorMessage, "project.toml")
 }
 
 func retrieveAcm(id string, client *heroku.Service) (bool, error) {

--- a/heroku/resource_heroku_app.go
+++ b/heroku/resource_heroku_app.go
@@ -668,9 +668,7 @@ func (a *application) Update() error {
 	var errs []error
 	var err error
 
-	// Only retrieve buildpacks for apps using traditional buildpacks.
-	// Cedar apps with stack = "cnb" and all fir apps use CNB instead.
-	if IsFeatureSupported(a.Generation, "app", "buildpacks") && !IsCNBApp(a.Generation, a.App.Stack) {
+	if !IsCNBApp(a.Generation, a.App.Stack) {
 		a.Buildpacks, err = retrieveBuildpacks(a.Id, a.Client)
 		if err != nil {
 			errs = append(errs, err)

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -1064,7 +1064,7 @@ func TestHerokuAppGeneration(t *testing.T) {
 		{name: "Cedar buildpacks should be supported", generation: "cedar", feature: "buildpacks", expected: true},
 		{name: "Cedar stack should be supported", generation: "cedar", feature: "stack", expected: true},
 		{name: "Cedar internal_routing should be supported", generation: "cedar", feature: "internal_routing", expected: true},
-		{name: "Cedar cloud_native_buildpacks should be unsupported", generation: "cedar", feature: "cloud_native_buildpacks", expected: false},
+		{name: "Cedar cloud_native_buildpacks should be supported", generation: "cedar", feature: "cloud_native_buildpacks", expected: true},
 
 		// Fir app features - traditional features should be unsupported, CNB should be supported
 		{name: "Fir buildpacks should be unsupported", generation: "fir", feature: "buildpacks", expected: false},

--- a/heroku/resource_heroku_build.go
+++ b/heroku/resource_heroku_build.go
@@ -412,8 +412,8 @@ func validateBuildpacksForAppGeneration(ctx context.Context, diff *schema.Resour
 		return nil
 	}
 
-	// Validate buildpacks against app generation
-	return validateBuildpacksForGeneration(app.Generation.Name)
+	// Validate buildpacks against app generation and stack
+	return validateBuildpacksForGenerationAndStack(app.Generation.Name, app.BuildStack.Name)
 }
 
 // validateBuildpacksForApp validates buildpack configuration at apply-time
@@ -423,25 +423,26 @@ func validateBuildpacksForApp(client *heroku.Service, appID string, d *schema.Re
 		return nil // No buildpacks specified, nothing to validate
 	}
 
-	// Fetch app info to determine its generation
+	// Fetch app info to determine its generation and stack
 	app, err := client.AppInfo(context.TODO(), appID)
 	if err != nil {
 		return fmt.Errorf("failed to get app info for build validation: %w", err)
 	}
 
-	// Validate buildpacks against app generation
-	return validateBuildpacksForGeneration(app.Generation.Name)
+	// Validate buildpacks against app generation and stack
+	return validateBuildpacksForGenerationAndStack(app.Generation.Name, app.BuildStack.Name)
 }
 
-// validateBuildpacksForGeneration validates buildpacks against a given generation
-func validateBuildpacksForGeneration(generationName string) error {
-	appGeneration := generationName
-	if appGeneration == "" {
-		appGeneration = "cedar" // Default to cedar if generation is not specified
+// validateBuildpacksForGenerationAndStack validates that traditional buildpacks are not
+// used with CNB apps. Fir apps always use CNB; Cedar apps use CNB when stack = "cnb".
+func validateBuildpacksForGenerationAndStack(generationName, stackName string) error {
+	generation := generationName
+	if generation == "" {
+		generation = "cedar"
 	}
 
-	if !IsFeatureSupported(appGeneration, "app", "buildpacks") {
-		return fmt.Errorf("buildpacks cannot be specified for %s generation apps. Use project.toml to configure Cloud Native Buildpacks instead. See: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app", appGeneration)
+	if !IsFeatureSupported(generation, "app", "buildpacks") || IsCNBApp(generation, stackName) {
+		return fmt.Errorf("buildpacks cannot be specified for apps using Cloud Native Buildpacks. Use project.toml instead. See: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app")
 	}
 
 	return nil

--- a/heroku/resource_heroku_build_test.go
+++ b/heroku/resource_heroku_build_test.go
@@ -496,11 +496,11 @@ func TestHerokuBuildGeneration(t *testing.T) {
 			expectedSupported: false,
 		},
 		{
-			name:              "Cedar apps should not support cloud_native_buildpacks",
+			name:              "Cedar apps should support cloud_native_buildpacks",
 			generation:        "cedar",
 			resourceType:      "app",
 			feature:           "cloud_native_buildpacks",
-			expectedSupported: false,
+			expectedSupported: true,
 		},
 		{
 			name:              "Fir apps should support cloud_native_buildpacks",

--- a/heroku/resource_heroku_build_test.go
+++ b/heroku/resource_heroku_build_test.go
@@ -524,6 +524,30 @@ func TestHerokuBuildGeneration(t *testing.T) {
 	}
 }
 
+// TestValidateBuildpacksForGenerationAndStack tests that CNB apps reject traditional buildpacks
+func TestValidateBuildpacksForGenerationAndStack(t *testing.T) {
+	tests := []struct {
+		name       string
+		generation string
+		stack      string
+		wantErr    bool
+	}{
+		{"cedar with heroku-22 allows buildpacks", "cedar", "heroku-22", false},
+		{"cedar with empty stack allows buildpacks", "cedar", "", false},
+		{"cedar with cnb stack rejects buildpacks", "cedar", "cnb", true},
+		{"fir always rejects buildpacks", "fir", "cnb", true},
+		{"fir with empty stack rejects buildpacks", "fir", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBuildpacksForGenerationAndStack(tt.generation, tt.stack)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateBuildpacksForGenerationAndStack(%q, %q) error = %v, wantErr %v", tt.generation, tt.stack, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // testStep_AccHerokuBuild_Generation_FirValid tests that Fir builds work without buildpacks
 func testStep_AccHerokuBuild_Generation_FirValid(spaceConfig, spaceName string) resource.TestStep {
 	return resource.TestStep{


### PR DESCRIPTION
## Description

Cedar-generation apps can now opt into Cloud Native Buildpacks by setting `stack = "cnb"`. Previously, CNB was exclusive to Fir-generation apps. This change extends CNB support to Cedar while keeping traditional buildpacks working for existing Cedar apps that don't set `stack = "cnb"`.

Related: W-23144558

## Changes

- Add `IsCNBApp(generation, stack string) bool` helper — canonical check for whether an app instance is using CNB
- Update feature matrix: Cedar `cloud_native_buildpacks` is now `true`
- Guard `BuildpackInstallationList` call in app resource against Cedar CNB apps (the API returns a 422 for CNB apps; we skip the call entirely)
- Make buildpack validation in build resource stack-aware — Cedar apps with `stack = "cnb"` now reject traditional buildpacks at plan and apply time
- Remove unused `isCNBError` helper

## Usage

```hcl
resource "heroku_app" "example" {
  name   = "my-cedar-cnb-app"
  region = "us"

  # Opts this Cedar app into Cloud Native Buildpacks.
  # Configure buildpacks via project.toml, not the buildpacks attribute.
  stack = "cnb"
}
```

Existing Cedar apps using traditional buildpacks are unaffected.