### PR TITLE
fix(tests): require org for all personal-app acceptance tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -35,7 +35,7 @@ The following parameters are available for running the test. The absence of some
 
 * **HEROKU_API_KEY**(`string`) **Required** The api key of the user running the test.
 * **HEROKU_EMAIL**(`string`) **Required** The email of the user running the test.
-* **HEROKU_ORGANIZATION**(`string`) **Required** The Heroku Team in which tests will be run.
+* **HEROKU_ORGANIZATION**(`string`) **Required** The Heroku Team in which tests will be run. All acceptance test apps are created under this team. Salesforce internal (`@salesforce.com`) accounts cannot create personal apps — all apps must belong to a team — so this value must be set when running tests with an internal account.
 * **HEROKU_TEST_USER**(`string`) The name of an existing user belonging to the organization, that will be used for various test cases.
 * **HEROKU_NON_ADMIN_TEST_USER**(`string`) The name of an existing non-admin user belonging to the organization, that will be used for various test cases.
 * **HEROKU_SLUG_ID**(`string`) The ID of an existing slug built in the Common Runtime (otherwise "Slug not compatible with space" errors will be thrown)

--- a/heroku/data_source_heroku_addon_test.go
+++ b/heroku/data_source_heroku_addon_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccDatasourceHerokuAddon_Basic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -18,10 +19,10 @@ func TestAccDatasourceHerokuAddon_Basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonBasic(appName),
+				Config: testAccCheckHerokuAddonBasic(appName, org),
 			},
 			{
-				Config: testAccCheckHerokuAddonWithDatasourceBasic(appName),
+				Config: testAccCheckHerokuAddonWithDatasourceBasic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.heroku_addon.test_data", "app_id"),
@@ -33,11 +34,14 @@ func TestAccDatasourceHerokuAddon_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckHerokuAddonBasic(appName string) string {
+func testAccCheckHerokuAddonBasic(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_addon" "foobar" {
@@ -47,14 +51,17 @@ resource "heroku_addon" "foobar" {
 		url = "http://google.com"
 	}
 }
-`, appName)
+`, appName, org)
 }
 
-func testAccCheckHerokuAddonWithDatasourceBasic(appName string) string {
+func testAccCheckHerokuAddonWithDatasourceBasic(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_addon" "foobar" {
@@ -68,5 +75,5 @@ resource "heroku_addon" "foobar" {
 data "heroku_addon" "test_data" {
   name = "${heroku_addon.foobar.id}"
 }
-`, appName)
+`, appName, org)
 }

--- a/heroku/data_source_heroku_app_test.go
+++ b/heroku/data_source_heroku_app_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccDatasourceHerokuApp_Basic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 	gitUrl := fmt.Sprintf("https://git.heroku.com/%s.git", appName)
 
 	resource.Test(t, resource.TestCase{
@@ -18,7 +19,7 @@ func TestAccDatasourceHerokuApp_Basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppWithDatasource_basic(appName),
+				Config: testAccCheckHerokuAppWithDatasource_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.heroku_app.foobar", "name", appName),
@@ -44,13 +45,14 @@ func TestAccDatasourceHerokuApp_Basic(t *testing.T) {
 
 func TestAccDatasourceHerokuApp_ReleaseIDAndSlugID(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppWithDatasource_slugRelease(appName),
+				Config: testAccCheckHerokuAppWithDatasource_slugRelease(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.heroku_app.foobar", "last_release_id"),
@@ -143,17 +145,21 @@ resource "heroku_app" "foobar" {
 `, appName)
 }
 
-func testAccCheckHerokuAppWithDatasource_basic(appName string) string {
+func testAccCheckHerokuAppWithDatasource_basic(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
 
+  organization {
+    name = "%s"
+  }
+
   buildpacks = [
     "https://github.com/heroku/heroku-buildpack-multi-procfile",
     "heroku/go"
 	]
-	
+
 	config_vars = {
     FOO = "bar"
 	}
@@ -162,14 +168,17 @@ resource "heroku_app" "foobar" {
 data "heroku_app" "foobar" {
   name = "${heroku_app.foobar.name}"
 }
-`, appName)
+`, appName, org)
 }
 
-func testAccCheckHerokuAppWithDatasource_slugRelease(appName string) string {
+func testAccCheckHerokuAppWithDatasource_slugRelease(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "foobar" {
@@ -191,7 +200,7 @@ data "heroku_app" "foobar" {
 
   depends_on = [heroku_app_release.foobar]
 }
-`, appName)
+`, appName, org)
 }
 
 func testAccCheckHerokuApp_organization(appName, orgName string) string {

--- a/heroku/data_source_heroku_pipeline_test.go
+++ b/heroku/data_source_heroku_pipeline_test.go
@@ -11,6 +11,7 @@ import (
 func TestAccDatasourceHerokuPipeline_Basic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	pipelineName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -19,7 +20,7 @@ func TestAccDatasourceHerokuPipeline_Basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuPipelineWithDatasourceBasic(appName, pipelineName),
+				Config: testAccCheckHerokuPipelineWithDatasourceBasic(appName, pipelineName, org),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.heroku_pipeline.foobar", "name", pipelineName),
@@ -35,11 +36,14 @@ func TestAccDatasourceHerokuPipeline_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckHerokuPipelineWithDatasourceBasic(appName, pipelineName string) string {
+func testAccCheckHerokuPipelineWithDatasourceBasic(appName, pipelineName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "staging" {
   name = "%s"
   region = "us"
+  organization {
+    name = "%s"
+  }
 }
 
 resource "heroku_pipeline" "foobar" {
@@ -55,5 +59,5 @@ resource "heroku_pipeline_coupling" "staging" {
 data "heroku_pipeline" "foobar" {
   name = heroku_pipeline_coupling.staging.pipeline
 }
-`, appName, pipelineName)
+`, appName, org, pipelineName)
 }

--- a/heroku/data_source_heroku_pipeline_test.go
+++ b/heroku/data_source_heroku_pipeline_test.go
@@ -38,6 +38,10 @@ func TestAccDatasourceHerokuPipeline_Basic(t *testing.T) {
 
 func testAccCheckHerokuPipelineWithDatasourceBasic(appName, pipelineName, org string) string {
 	return fmt.Sprintf(`
+data "heroku_team" "foobar" {
+  name = "%s"
+}
+
 resource "heroku_app" "staging" {
   name = "%s"
   region = "us"
@@ -48,6 +52,10 @@ resource "heroku_app" "staging" {
 
 resource "heroku_pipeline" "foobar" {
   name = "%s"
+  owner {
+    id   = data.heroku_team.foobar.id
+    type = "team"
+  }
 }
 
 resource "heroku_pipeline_coupling" "staging" {
@@ -59,5 +67,5 @@ resource "heroku_pipeline_coupling" "staging" {
 data "heroku_pipeline" "foobar" {
   name = heroku_pipeline_coupling.staging.pipeline
 }
-`, appName, org, pipelineName)
+`, org, appName, org, pipelineName)
 }

--- a/heroku/import_heroku_addon_attachment_test.go
+++ b/heroku/import_heroku_addon_attachment_test.go
@@ -10,13 +10,14 @@ import (
 
 func TestAccHerokuAddonAttachment_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonAttachmentConfig_basic(appName),
+				Config: testAccCheckHerokuAddonAttachmentConfig_basic(appName, org),
 			},
 			{
 				ResourceName: "heroku_addon_attachment.foobar",

--- a/heroku/import_heroku_addon_test.go
+++ b/heroku/import_heroku_addon_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccHerokuAddon_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +18,7 @@ func TestAccHerokuAddon_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonConfig_basic(appName),
+				Config: testAccCheckHerokuAddonConfig_basic(appName, org),
 			},
 			{
 				ResourceName:            "heroku_addon.foobar",
@@ -26,7 +27,7 @@ func TestAccHerokuAddon_importBasic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"config_vars", "config"},
 			},
 			{
-				Config:             testAccCheckHerokuAddonConfig_basic(appName),
+				Config:             testAccCheckHerokuAddonConfig_basic(appName, org),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},

--- a/heroku/import_heroku_app_feature_test.go
+++ b/heroku/import_heroku_app_feature_test.go
@@ -9,13 +9,14 @@ import (
 
 func TestAccHerokuAppFeature_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuFeature_basic(appName),
+				Config: testAccCheckHerokuFeature_basic(appName, org),
 			},
 			{
 				ResourceName:      "heroku_app_feature.runtime_metrics",

--- a/heroku/import_heroku_app_release_test.go
+++ b/heroku/import_heroku_app_release_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccHerokuAppRelease_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetAnyOrganizationOrSkip(t)
 	slugID := testAccConfig.GetSlugIDOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
@@ -20,7 +21,7 @@ func TestAccHerokuAppRelease_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppRelease_Basic(appName, slugID),
+				Config: testAccCheckHerokuAppRelease_Basic(appName, org, slugID),
 			},
 			{
 				ResourceName:      "heroku_app_release.foobar-release",

--- a/heroku/import_heroku_app_test.go
+++ b/heroku/import_heroku_app_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccHerokuApp_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +18,7 @@ func TestAccHerokuApp_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_basic(appName),
+				Config: testAccCheckHerokuAppConfig_basic(appName, org),
 			},
 			{
 				ResourceName:      "heroku_app.foobar",
@@ -59,6 +60,7 @@ func TestAccHerokuApp_importOrganization(t *testing.T) {
 
 func TestAccHerokuApp_importBuildpacks(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -68,7 +70,7 @@ func TestAccHerokuApp_importBuildpacks(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_multi(appName),
+				Config: testAccCheckHerokuAppConfig_multi(appName, org),
 			},
 			{
 				ResourceName:      "heroku_app.foobar",

--- a/heroku/import_heroku_app_webhook_test.go
+++ b/heroku/import_heroku_app_webhook_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccHerokuAppWebhook_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -18,7 +19,7 @@ func TestAccHerokuAppWebhook_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppWebhookConfig(appName, "https://terraform.example.com:4321", "sync", "api:build"),
+				Config: testAccCheckHerokuAppWebhookConfig(appName, org, "https://terraform.example.com:4321", "sync", "api:build"),
 			},
 			{
 				ResourceName:        "heroku_app_webhook.foobar_webhook",

--- a/heroku/import_heroku_build_test.go
+++ b/heroku/import_heroku_build_test.go
@@ -10,13 +10,14 @@ import (
 
 func TestAccHerokuBuild_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_basic(appName),
+				Config: testAccCheckHerokuBuildConfig_basic(appName, org),
 			},
 			{
 				ResourceName:            "heroku_build.foobar",
@@ -31,13 +32,14 @@ func TestAccHerokuBuild_importBasic(t *testing.T) {
 
 func TestAccHerokuBuild_importAllOpts(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_allOpts(appName),
+				Config: testAccCheckHerokuBuildConfig_allOpts(appName, org),
 			},
 			{
 				ResourceName:            "heroku_build.foobar",
@@ -52,13 +54,14 @@ func TestAccHerokuBuild_importAllOpts(t *testing.T) {
 
 func TestAccHerokuBuild_importWithFileUrl(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_localSourceTarball(appName),
+				Config: testAccCheckHerokuBuildConfig_localSourceTarball(appName, org),
 			},
 			{
 				ResourceName:            "heroku_build.foobar",

--- a/heroku/import_heroku_collaborator_test.go
+++ b/heroku/import_heroku_collaborator_test.go
@@ -11,6 +11,7 @@ import (
 func TestAccHerokuCollaborator_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	testUser := testAccConfig.GetNonAdminUserOrAbort(t)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -19,7 +20,7 @@ func TestAccHerokuCollaborator_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuCollaborator_Basic(appName, testUser),
+				Config: testAccCheckHerokuCollaborator_Basic(appName, testUser, org),
 			},
 			{
 				ResourceName:            "heroku_collaborator.foobar-collaborator",

--- a/heroku/import_heroku_domain_test.go
+++ b/heroku/import_heroku_domain_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccHerokuDomain_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +18,7 @@ func TestAccHerokuDomain_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDomainConfig_basic(appName),
+				Config: testAccCheckHerokuDomainConfig_basic(appName, org),
 			},
 			{
 				ResourceName:        "heroku_domain.one",
@@ -30,6 +31,7 @@ func TestAccHerokuDomain_importBasic(t *testing.T) {
 
 func TestAccHerokuDomain_importSSL(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,7 +39,7 @@ func TestAccHerokuDomain_importSSL(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDomainConfig_ssl(appName),
+				Config: testAccCheckHerokuDomainConfig_ssl(appName, org),
 			},
 			{
 				ResourceName:        "heroku_domain.one",

--- a/heroku/import_heroku_drain_test.go
+++ b/heroku/import_heroku_drain_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAccHerokuDrain_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,7 +20,7 @@ func TestAccHerokuDrain_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDrainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDrainConfig_basic(appName),
+				Config: testAccCheckHerokuDrainConfig_basic(appName, org),
 			},
 			{
 				ResourceName:        "heroku_drain.foobar",
@@ -33,6 +34,7 @@ func TestAccHerokuDrain_importBasic(t *testing.T) {
 
 func TestAccHerokuDrain_importBasicWithSensitiveURL(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,7 +42,7 @@ func TestAccHerokuDrain_importBasicWithSensitiveURL(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDrainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDrainConfig_basicWithSensitiveURL(appName),
+				Config: testAccCheckHerokuDrainConfig_basicWithSensitiveURL(appName, org),
 			},
 			{
 				ResourceName:      "heroku_drain.foobar",

--- a/heroku/import_heroku_pipeline_coupling_test.go
+++ b/heroku/import_heroku_pipeline_coupling_test.go
@@ -15,6 +15,7 @@ func TestAccHerokuPipelineCoupling_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	pipelineName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	stageName := "development"
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,7 +23,7 @@ func TestAccHerokuPipelineCoupling_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuPipelineCouplingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuPipelineCouplingConfig_basic(appName, pipelineName, stageName),
+				Config: testAccCheckHerokuPipelineCouplingConfig_basic(appName, pipelineName, stageName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuPipelineCouplingExists("heroku_pipeline_coupling.default", &coupling),
 					testAccCheckHerokuPipelineCouplingAttributes(

--- a/heroku/import_heroku_slug_test.go
+++ b/heroku/import_heroku_slug_test.go
@@ -10,13 +10,14 @@ import (
 
 func TestAccHerokuSlug_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSlugConfig_basic(appName),
+				Config: testAccCheckHerokuSlugConfig_basic(appName, org),
 			},
 			{
 				ResourceName:        "heroku_slug.foobar",
@@ -33,13 +34,14 @@ func TestAccHerokuSlug_importBasic(t *testing.T) {
 
 func TestAccHerokuSlug_importAllOpts(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSlugConfig_allOpts(appName),
+				Config: testAccCheckHerokuSlugConfig_allOpts(appName, org),
 			},
 			{
 				ResourceName:        "heroku_slug.foobar",
@@ -56,13 +58,14 @@ func TestAccHerokuSlug_importAllOpts(t *testing.T) {
 
 func TestAccHerokuSlug_importWithFileUrl(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSlugConfig_withRemoteFile(appName),
+				Config: testAccCheckHerokuSlugConfig_withRemoteFile(appName, org),
 			},
 			{
 				ResourceName:        "heroku_slug.foobar",

--- a/heroku/import_heroku_ssl_test.go
+++ b/heroku/import_heroku_ssl_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccHerokuSSL_importBasic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	wd, _ := os.Getwd()
 	certFile := wd + "/test-fixtures/terraform.cert"
@@ -22,7 +23,7 @@ func TestAccHerokuSSL_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuSSLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSSLConfig(appName, certFile, keyFile),
+				Config: testAccCheckHerokuSSLConfig(appName, org, certFile, keyFile),
 			},
 			{
 				ResourceName:            "heroku_ssl.one",

--- a/heroku/resource_heroku_addon_attachment_test.go
+++ b/heroku/resource_heroku_addon_attachment_test.go
@@ -10,12 +10,13 @@ import (
 
 func TestAccHerokuAddonAttachment_Basic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonAttachmentConfig_basic(appName),
+				Config: testAccCheckHerokuAddonAttachmentConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"heroku_addon_attachment.foobar", "app_id"),
@@ -29,12 +30,13 @@ func TestAccHerokuAddonAttachment_Basic(t *testing.T) {
 
 func TestAccHerokuAddonAttachment_Named(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonAttachmentConfig_named(appName, "TEST_ADDON"),
+				Config: testAccCheckHerokuAddonAttachmentConfig_named(appName, org, "TEST_ADDON"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"heroku_addon_attachment.foobar", "app_id"),
@@ -46,11 +48,15 @@ func TestAccHerokuAddonAttachment_Named(t *testing.T) {
 	})
 }
 
-func testAccCheckHerokuAddonAttachmentConfig_basic(appID string) string {
+func testAccCheckHerokuAddonAttachmentConfig_basic(appID, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
 	name   = "%s"
 	region = "us"
+
+	organization {
+		name = "%s"
+	}
 }
 
 resource "heroku_addon" "foobar" {
@@ -62,14 +68,18 @@ resource "heroku_addon_attachment" "foobar" {
     app_id    = heroku_app.foobar.id
     addon_id  = heroku_addon.foobar.id
     namespace = "TEST_NAMESPACE"
-}`, appID)
+}`, appID, org)
 }
 
-func testAccCheckHerokuAddonAttachmentConfig_named(appID string, name string) string {
+func testAccCheckHerokuAddonAttachmentConfig_named(appID, org, name string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
 	name   = "%s"
 	region = "us"
+
+	organization {
+		name = "%s"
+	}
 }
 
 resource "heroku_addon" "foobar" {
@@ -81,5 +91,5 @@ resource "heroku_addon_attachment" "foobar" {
     app_id   = heroku_app.foobar.id
     addon_id = heroku_addon.foobar.id
     name     = "%s"
-}`, appID, name)
+}`, appID, org, name)
 }

--- a/heroku/resource_heroku_addon_test.go
+++ b/heroku/resource_heroku_addon_test.go
@@ -16,6 +16,7 @@ import (
 func TestAccHerokuAddon_Basic(t *testing.T) {
 	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,7 +24,7 @@ func TestAccHerokuAddon_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonConfig_basic(appName),
+				Config: testAccCheckHerokuAddonConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
 					testAccCheckHerokuAddonPlan(&addon, "scheduler:standard"),
@@ -40,6 +41,7 @@ func TestAccHerokuAddon_Basic(t *testing.T) {
 func TestAccHerokuAddon_noPlan(t *testing.T) {
 	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -47,7 +49,7 @@ func TestAccHerokuAddon_noPlan(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonConfig_no_plan(appName),
+				Config: testAccCheckHerokuAddonConfig_no_plan(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
 					testAccCheckHerokuAddonPlan(&addon, "heroku-postgresql:essential-0"),
@@ -58,7 +60,7 @@ func TestAccHerokuAddon_noPlan(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckHerokuAddonConfig_no_plan(appName),
+				Config: testAccCheckHerokuAddonConfig_no_plan(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
 					testAccCheckHerokuAddonPlan(&addon, "heroku-postgresql:essential-0"),
@@ -75,6 +77,7 @@ func TestAccHerokuAddon_noPlan(t *testing.T) {
 func TestAccHerokuAddon_ConfigVarValues(t *testing.T) {
 	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,7 +85,7 @@ func TestAccHerokuAddon_ConfigVarValues(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonConfig_configVarValues(appName),
+				Config: testAccCheckHerokuAddonConfig_configVarValues(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.pg", &addon),
 					testAccCheckHerokuAddonPlan(&addon, "heroku-postgresql:essential-0"),
@@ -95,13 +98,14 @@ func TestAccHerokuAddon_ConfigVarValues(t *testing.T) {
 
 func TestAccHerokuAddon_DontSetConfigVarValues(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonConfig_dontSetConfigVarValues(appName),
+				Config: testAccCheckHerokuAddonConfig_dontSetConfigVarValues(appName, org),
 				Check: resource.TestCheckNoResourceAttr(
 					"heroku_addon.pg", "config_var_values.DATABASE_URL"),
 			},
@@ -113,6 +117,7 @@ func TestAccHerokuAddon_CustomName(t *testing.T) {
 	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	customName := fmt.Sprintf("custom-addonname-%s", acctest.RandString(15))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -120,7 +125,7 @@ func TestAccHerokuAddon_CustomName(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonConfig_CustomName(appName, customName),
+				Config: testAccCheckHerokuAddonConfig_CustomName(appName, org, customName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
 					testAccCheckHerokuAddonPlan(&addon, "heroku-postgresql:essential-0"),
@@ -139,6 +144,7 @@ func TestAccHerokuAddon_CustomName(t *testing.T) {
 func TestAccHerokuAddon_CustomName_Invalid(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	customName := "da.%dsadsa$d"
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -146,7 +152,7 @@ func TestAccHerokuAddon_CustomName_Invalid(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckHerokuAddonConfig_CustomName(appName, customName),
+				Config:      testAccCheckHerokuAddonConfig_CustomName(appName, org, customName),
 				ExpectError: regexp.MustCompile(`Invalid custom addon name.*`),
 			},
 		},
@@ -156,6 +162,7 @@ func TestAccHerokuAddon_CustomName_Invalid(t *testing.T) {
 func TestAccHerokuAddon_CustomName_EmptyString(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	customName := ""
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -163,7 +170,7 @@ func TestAccHerokuAddon_CustomName_EmptyString(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckHerokuAddonConfig_CustomName(appName, customName),
+				Config:      testAccCheckHerokuAddonConfig_CustomName(appName, org, customName),
 				ExpectError: regexp.MustCompile(`Invalid custom addon name.*`),
 			},
 		},
@@ -173,6 +180,7 @@ func TestAccHerokuAddon_CustomName_EmptyString(t *testing.T) {
 func TestAccHerokuAddon_CustomName_FirstCharNum(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	customName := "1dasdad"
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -180,7 +188,7 @@ func TestAccHerokuAddon_CustomName_FirstCharNum(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckHerokuAddonConfig_CustomName(appName, customName),
+				Config:      testAccCheckHerokuAddonConfig_CustomName(appName, org, customName),
 				ExpectError: regexp.MustCompile(`Invalid custom addon name.*`),
 			},
 		},
@@ -190,6 +198,7 @@ func TestAccHerokuAddon_CustomName_FirstCharNum(t *testing.T) {
 func TestAccHerokuAddon_Disappears(t *testing.T) {
 	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -197,7 +206,7 @@ func TestAccHerokuAddon_Disappears(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAddonConfig_basic(appName),
+				Config: testAccCheckHerokuAddonConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
 					testAccCheckHerokuAddonDisappears(appName, "scheduler"),
@@ -300,11 +309,14 @@ func testAccCheckHerokuAddonDisappears(appName, addonName string) resource.TestC
 	}
 }
 
-func testAccCheckHerokuAddonConfig_basic(appName string) string {
+func testAccCheckHerokuAddonConfig_basic(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_addon" "foobar" {
@@ -313,23 +325,26 @@ resource "heroku_addon" "foobar" {
     config = {
         url = "http://google.com"
 	}
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuAddonConfig_configVarValues(appName string) string {
+func testAccCheckHerokuAddonConfig_configVarValues(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_addon" "pg" {
     app_id = heroku_app.foobar.id
     plan = "heroku-postgresql"
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuAddonConfig_dontSetConfigVarValues(appName string) string {
+func testAccCheckHerokuAddonConfig_dontSetConfigVarValues(appName, org string) string {
 	return fmt.Sprintf(`
 provider "heroku" {
   customizations {
@@ -340,37 +355,46 @@ provider "heroku" {
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_addon" "pg" {
     app_id = heroku_app.foobar.id
     plan = "heroku-postgresql"
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuAddonConfig_no_plan(appName string) string {
+func testAccCheckHerokuAddonConfig_no_plan(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_addon" "foobar" {
     app_id = heroku_app.foobar.id
     plan = "heroku-postgresql"
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuAddonConfig_CustomName(appName, customAddonName string) string {
+func testAccCheckHerokuAddonConfig_CustomName(appName, org, customAddonName string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_addon" "foobar" {
     app_id = heroku_app.foobar.id
     plan = "heroku-postgresql"
     name = "%s"
-}`, appName, customAddonName)
+}`, appName, org, customAddonName)
 }

--- a/heroku/resource_heroku_app_feature_test.go
+++ b/heroku/resource_heroku_app_feature_test.go
@@ -18,6 +18,7 @@ import (
 func TestAccHerokuAppFeature(t *testing.T) {
 	var feature heroku.AppFeature
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,7 +26,7 @@ func TestAccHerokuAppFeature(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuFeatureDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuFeature_basic(appName),
+				Config: testAccCheckHerokuFeature_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuFeatureExists("heroku_app_feature.runtime_metrics", &feature),
 					testAccCheckHerokuFeatureEnabled(&feature, true),
@@ -35,7 +36,7 @@ func TestAccHerokuAppFeature(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckHerokuFeature_disabled(appName),
+				Config: testAccCheckHerokuFeature_disabled(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuFeatureExists("heroku_app_feature.runtime_metrics", &feature),
 					testAccCheckHerokuFeatureEnabled(&feature, false),
@@ -149,25 +150,33 @@ func testAccCheckHerokuFeatureEnabled(feature *heroku.AppFeature, enabled bool) 
 	}
 }
 
-func testAccCheckHerokuFeature_basic(appName string) string {
+func testAccCheckHerokuFeature_basic(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "example" {
 	name = "%s"
 	region = "us"
+
+	organization {
+		name = "%s"
+	}
 }
 
 resource "heroku_app_feature" "runtime_metrics" {
 	app_id = heroku_app.example.id
 	name = "log-runtime-metrics"
 }
-`, appName)
+`, appName, org)
 }
 
-func testAccCheckHerokuFeature_disabled(appName string) string {
+func testAccCheckHerokuFeature_disabled(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "example" {
 	name = "%s"
 	region = "us"
+
+	organization {
+		name = "%s"
+	}
 }
 
 resource "heroku_app_feature" "runtime_metrics" {
@@ -175,5 +184,5 @@ resource "heroku_app_feature" "runtime_metrics" {
 	name = "log-runtime-metrics"
 	enabled = false
 }
-`, appName)
+`, appName, org)
 }

--- a/heroku/resource_heroku_app_release_test.go
+++ b/heroku/resource_heroku_app_release_test.go
@@ -15,6 +15,7 @@ func TestAccHerokuAppRelease_Basic(t *testing.T) {
 	var appRelease heroku.Release
 
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetAnyOrganizationOrSkip(t)
 	slugID := testAccConfig.GetSlugIDOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
@@ -25,7 +26,7 @@ func TestAccHerokuAppRelease_Basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppRelease_Basic(appName, slugID),
+				Config: testAccCheckHerokuAppRelease_Basic(appName, org, slugID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppReleaseExists("heroku_app_release.foobar-release", &appRelease),
 					resource.TestCheckResourceAttr(
@@ -95,17 +96,20 @@ func testAccCheckHerokuAppReleaseExists(n string, appRelease *heroku.Release) re
 	}
 }
 
-func testAccCheckHerokuAppRelease_Basic(appName, slugId string) string {
+func testAccCheckHerokuAppRelease_Basic(appName, org, slugId string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
 	name = "%s"
 	region = "us"
+	organization {
+		name = "%s"
+	}
 }
 resource "heroku_app_release" "foobar-release" {
 	app_id = heroku_app.foobar.id
 	slug_id = "%s"
 }
-`, appName, slugId)
+`, appName, org, slugId)
 }
 
 func testAccCheckHerokuAppRelease_OrgBasic(appName, org, slugId, desc string) string {

--- a/heroku/resource_heroku_app_test.go
+++ b/heroku/resource_heroku_app_test.go
@@ -20,6 +20,7 @@ import (
 func TestAccHerokuApp_Basic(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,7 +28,7 @@ func TestAccHerokuApp_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_basic(appName),
+				Config: testAccCheckHerokuAppConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppAttributes(&app, appName),
@@ -59,13 +60,14 @@ func TestAccHerokuApp_Basic(t *testing.T) {
 
 func TestAccHerokuApp_DontSetAllConfigVars(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_DontSetConfigVars(appName),
+				Config: testAccCheckHerokuAppConfig_DontSetConfigVars(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "name", appName),
@@ -86,6 +88,7 @@ func TestAccHerokuApp_DontSetAllConfigVars(t *testing.T) {
 func TestAccHerokuApp_Disappears(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -93,7 +96,7 @@ func TestAccHerokuApp_Disappears(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_basic(appName),
+				Config: testAccCheckHerokuAppConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppDisappears(appName),
@@ -108,6 +111,7 @@ func TestAccHerokuApp_Change(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	appName2 := fmt.Sprintf("%s-v2", appName)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -115,7 +119,7 @@ func TestAccHerokuApp_Change(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_basic(appName),
+				Config: testAccCheckHerokuAppConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppAttributes(&app, appName),
@@ -126,7 +130,7 @@ func TestAccHerokuApp_Change(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckHerokuAppConfig_updated(appName2),
+				Config: testAccCheckHerokuAppConfig_updated(appName2, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppAttributesUpdated(&app, appName2),
@@ -145,6 +149,7 @@ func TestAccHerokuApp_Change(t *testing.T) {
 func TestAccHerokuApp_NukeVars(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -152,7 +157,7 @@ func TestAccHerokuApp_NukeVars(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_basic(appName),
+				Config: testAccCheckHerokuAppConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppAttributes(&app, appName),
@@ -163,7 +168,7 @@ func TestAccHerokuApp_NukeVars(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckHerokuAppConfig_no_vars(appName),
+				Config: testAccCheckHerokuAppConfig_no_vars(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppAttributesNoVars(&app, appName),
@@ -180,6 +185,7 @@ func TestAccHerokuApp_NukeVars(t *testing.T) {
 func TestAccHerokuApp_Buildpacks(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -187,7 +193,7 @@ func TestAccHerokuApp_Buildpacks(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_go(appName),
+				Config: testAccCheckHerokuAppConfig_go(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppBuildpacks(appName, false),
@@ -195,7 +201,7 @@ func TestAccHerokuApp_Buildpacks(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckHerokuAppConfig_multi(appName),
+				Config: testAccCheckHerokuAppConfig_multi(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppBuildpacks(appName, true),
@@ -205,7 +211,7 @@ func TestAccHerokuApp_Buildpacks(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckHerokuAppConfig_no_vars(appName),
+				Config: testAccCheckHerokuAppConfig_no_vars(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppNoBuildpacks(appName),
@@ -219,6 +225,7 @@ func TestAccHerokuApp_Buildpacks(t *testing.T) {
 func TestAccHerokuApp_ExternallySetBuildpacks(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -226,7 +233,7 @@ func TestAccHerokuApp_ExternallySetBuildpacks(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_no_vars(appName),
+				Config: testAccCheckHerokuAppConfig_no_vars(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppNoBuildpacks(appName),
@@ -235,7 +242,7 @@ func TestAccHerokuApp_ExternallySetBuildpacks(t *testing.T) {
 			},
 			{
 				PreConfig: testAccInstallUnconfiguredBuildpack(t, appName),
-				Config:    testAccCheckHerokuAppConfig_no_vars(appName),
+				Config:    testAccCheckHerokuAppConfig_no_vars(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					resource.TestCheckNoResourceAttr("heroku_app.foobar", "buildpacks.0"),
@@ -341,6 +348,7 @@ func testStep_AccHerokuApp_Space_Internal(t *testing.T, spaceConfig, spaceName s
 func TestAccHerokuApp_EmptyConfigVars(t *testing.T) {
 	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -348,7 +356,7 @@ func TestAccHerokuApp_EmptyConfigVars(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppConfig_EmptyConfigVars(appName),
+				Config: testAccCheckHerokuAppConfig_EmptyConfigVars(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppExists("heroku_app.foobar", &app),
 					testAccCheckHerokuAppAttributesNoVars(&app, appName),
@@ -758,64 +766,84 @@ func testAccCheckHerokuAppDisappears(appName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckHerokuAppConfig_basic(appName string) string {
+func testAccCheckHerokuAppConfig_basic(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
+
+  organization {
+    name = "%s"
+  }
 
   config_vars = {
     FOO = "bar"
   }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuAppConfig_go(appName string) string {
+func testAccCheckHerokuAppConfig_go(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
+
+  organization {
+    name = "%s"
+  }
 
   buildpacks = ["heroku/go"]
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuAppConfig_multi(appName string) string {
+func testAccCheckHerokuAppConfig_multi(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
+
+  organization {
+    name = "%s"
+  }
 
   buildpacks = [
     "https://github.com/heroku/heroku-buildpack-multi-procfile",
     "heroku/go"
   ]
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuAppConfig_updated(appName string) string {
+func testAccCheckHerokuAppConfig_updated(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
+
+  organization {
+    name = "%s"
+  }
 
   config_vars = {
     FOO = "bing"
     BAZ = "bar"
   }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuAppConfig_no_vars(appName string) string {
+func testAccCheckHerokuAppConfig_no_vars(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
 
+  organization {
+    name = "%s"
+  }
+
   buildpacks = []
 
   config_vars = {}
-}`, appName)
+}`, appName, org)
 }
 
 func testAccCheckHerokuAppConfig_organization(appName, org string) string {
@@ -875,12 +903,16 @@ resource "heroku_app" "foobar" {
 }`, spaceConfig, appName, org)
 }
 
-func testAccCheckHerokuAppConfig_EmptyConfigVars(appName string) string {
+func testAccCheckHerokuAppConfig_EmptyConfigVars(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
-}`, appName)
+
+  organization {
+    name = "%s"
+  }
+}`, appName, org)
 }
 
 func testAccCheckHerokuAppConfig_acm_enabled(appName, org string) string {
@@ -1032,7 +1064,7 @@ resource "heroku_app" "foobar" {
 }`, appName, org, locked)
 }
 
-func testAccCheckHerokuAppConfig_DontSetConfigVars(appName string) string {
+func testAccCheckHerokuAppConfig_DontSetConfigVars(appName, org string) string {
 	return fmt.Sprintf(`
 provider "heroku" {
   customizations {
@@ -1044,10 +1076,14 @@ resource "heroku_app" "foobar" {
   name   = "%s"
   region = "us"
 
+  organization {
+    name = "%s"
+  }
+
   config_vars = {
     FOO = "bar"
   }
-}`, appName)
+}`, appName, org)
 }
 
 // Unit tests for app generation support

--- a/heroku/resource_heroku_app_webhook_test.go
+++ b/heroku/resource_heroku_app_webhook_test.go
@@ -14,13 +14,14 @@ import (
 func TestAccHerokuAppWebhook_Basic(t *testing.T) {
 	var webhook heroku.AppWebhookInfoResult
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckHerokuAppWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuAppWebhookConfig(appName, "https://terraform.example.com:1234", "notify", "api:release"),
+				Config: testAccCheckHerokuAppWebhookConfig(appName, org, "https://terraform.example.com:1234", "notify", "api:release"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppWebhookExists("heroku_app_webhook.foobar_webhook", &webhook),
 					testAccCheckHerokuAppWebhookAttributes(&webhook, "https://terraform.example.com:1234", "notify", "api:release"),
@@ -30,7 +31,7 @@ func TestAccHerokuAppWebhook_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckHerokuAppWebhookConfig(appName, "https://terraform.example.com:4321", "sync", "api:build"),
+				Config: testAccCheckHerokuAppWebhookConfig(appName, org, "https://terraform.example.com:4321", "sync", "api:build"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAppWebhookExists("heroku_app_webhook.foobar_webhook", &webhook),
 					testAccCheckHerokuAppWebhookAttributes(&webhook, "https://terraform.example.com:4321", "sync", "api:build"),
@@ -43,11 +44,15 @@ func TestAccHerokuAppWebhook_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckHerokuAppWebhookConfig(appName, url, level, include string) string {
+func testAccCheckHerokuAppWebhookConfig(appName, org, url, level, include string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_app_webhook" "foobar_webhook" {
@@ -55,7 +60,7 @@ resource "heroku_app_webhook" "foobar_webhook" {
     url     = "%s"
     level   = "%s"
     include = ["%s"]
-}`, appName, url, level, include)
+}`, appName, org, url, level, include)
 }
 
 func testAccCheckHerokuAppWebhookDestroy(s *terraform.State) error {

--- a/heroku/resource_heroku_build_test.go
+++ b/heroku/resource_heroku_build_test.go
@@ -18,13 +18,14 @@ func TestAccHerokuBuild_Basic(t *testing.T) {
 	var build heroku.Build
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_basic(appName),
+				Config: testAccCheckHerokuBuildConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuBuildExists("heroku_build.foobar", &build),
 					resource.TestCheckResourceAttr("heroku_build.foobar", "status", "succeeded"),
@@ -37,6 +38,7 @@ func TestAccHerokuBuild_Basic(t *testing.T) {
 func TestAccHerokuBuild_Fails(t *testing.T) {
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -50,7 +52,7 @@ func TestAccHerokuBuild_Fails(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_fails(appName),
+				Config: testAccCheckHerokuBuildConfig_fails(appName, org),
 			},
 		},
 	})
@@ -59,13 +61,14 @@ func TestAccHerokuBuild_Fails(t *testing.T) {
 func TestAccHerokuBuild_InsecureUrl(t *testing.T) {
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckHerokuBuildConfig_insecureUrl(appName),
+				Config:      testAccCheckHerokuBuildConfig_insecureUrl(appName, org),
 				ExpectError: regexp.MustCompile(`must be a secure URL`),
 			},
 		},
@@ -75,13 +78,14 @@ func TestAccHerokuBuild_InsecureUrl(t *testing.T) {
 func TestAccHerokuBuild_NoSource(t *testing.T) {
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckHerokuBuildConfig_noSource(appName),
+				Config:      testAccCheckHerokuBuildConfig_noSource(appName, org),
 				ExpectError: regexp.MustCompile(`Build requires either`),
 			},
 		},
@@ -92,13 +96,14 @@ func TestAccHerokuBuild_AllOpts(t *testing.T) {
 	var build heroku.Build
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_allOpts(appName),
+				Config: testAccCheckHerokuBuildConfig_allOpts(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuBuildExists("heroku_build.foobar", &build),
 				),
@@ -111,6 +116,7 @@ func TestAccHerokuBuild_LocalSourceTarball(t *testing.T) {
 	var build, build2 heroku.Build
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 	// Manually generated using `shasum --algorithm 256 app.tgz`
 	// Manually generated using `shasum --algorithm 256 app-2.tgz`
 	// per Heroku docs https://devcenter.heroku.com/articles/slug-checksums
@@ -124,7 +130,7 @@ func TestAccHerokuBuild_LocalSourceTarball(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_localSourceTarball(appName),
+				Config: testAccCheckHerokuBuildConfig_localSourceTarball(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuBuildExists("heroku_build.foobar", &build),
 					resource.TestCheckResourceAttr("heroku_build.foobar", "local_checksum", sourceChecksum),
@@ -132,7 +138,7 @@ func TestAccHerokuBuild_LocalSourceTarball(t *testing.T) {
 			},
 			{
 				SkipFunc: switchSourceFiles,
-				Config:   testAccCheckHerokuBuildConfig_localSourceTarball(appName),
+				Config:   testAccCheckHerokuBuildConfig_localSourceTarball(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuBuildExists("heroku_build.foobar", &build2),
 					resource.TestCheckResourceAttr("heroku_build.foobar", "local_checksum", sourceChecksum2),
@@ -145,13 +151,14 @@ func TestAccHerokuBuild_LocalSourceTarball(t *testing.T) {
 func TestAccHerokuBuild_LocalSourceTarball_SetChecksum(t *testing.T) {
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckHerokuBuildConfig_localSourceTarball_setChecksum(appName),
+				Config:      testAccCheckHerokuBuildConfig_localSourceTarball_setChecksum(appName, org),
 				ExpectError: regexp.MustCompile(`checksum should be empty`),
 			},
 		},
@@ -162,13 +169,14 @@ func TestAccHerokuBuild_LocalSourceTarball_AllOpts(t *testing.T) {
 	var build heroku.Build
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_localSourceTarball_allOpts(appName),
+				Config: testAccCheckHerokuBuildConfig_localSourceTarball_allOpts(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuBuildExists("heroku_build.foobar", &build),
 				),
@@ -182,6 +190,7 @@ func TestAccHerokuBuild_LocalSourceDirectoryDiff(t *testing.T) {
 	var originalSourceChecksum string
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	defer resetSourceDirectories()
 
@@ -190,7 +199,7 @@ func TestAccHerokuBuild_LocalSourceDirectoryDiff(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_localSourceDirectory(appName),
+				Config: testAccCheckHerokuBuildConfig_localSourceDirectory(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuBuildExists("heroku_build.foobar", &build),
 					testAccCheckCaptureSourceChecksum("heroku_build.foobar", &originalSourceChecksum),
@@ -198,7 +207,7 @@ func TestAccHerokuBuild_LocalSourceDirectoryDiff(t *testing.T) {
 			},
 			{
 				SkipFunc: switchSourceDirectories,
-				Config:   testAccCheckHerokuBuildConfig_localSourceDirectory(appName),
+				Config:   testAccCheckHerokuBuildConfig_localSourceDirectory(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuBuildExists("heroku_build.foobar", &build2),
 					testAccCheckSourceChecksumIsDifferent("heroku_build.foobar", &originalSourceChecksum),
@@ -211,6 +220,7 @@ func TestAccHerokuBuild_LocalSourceDirectoryDiff(t *testing.T) {
 // https://github.com/heroku/terraform-provider-heroku/issues/160
 func TestAccHerokuBuild_LocalSourceDirectorySelfContained(t *testing.T) {
 	var build heroku.Build
+	org := testAccConfig.GetOrganizationOrSkip(t)
 	defer func() { _ = resetSourceDirectories() }()
 
 	// cd to the ./test-fixtures/app directory before and revert back afterwards
@@ -222,7 +232,7 @@ func TestAccHerokuBuild_LocalSourceDirectorySelfContained(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuBuildConfig_localSourceDirectorySelfContained(fmt.Sprintf("tftest-%s", acctest.RandString(10))),
+				Config: testAccCheckHerokuBuildConfig_localSourceDirectorySelfContained(fmt.Sprintf("tftest-%s", acctest.RandString(10)), org),
 				Check:  testAccCheckHerokuBuildExists("heroku_build.foobar", &build),
 			},
 		},
@@ -259,10 +269,13 @@ func testAccCheckHerokuBuildExists(n string, Build *heroku.Build) resource.TestC
 	}
 }
 
-func testAccCheckHerokuBuildConfig_basic(appName string) string {
+func testAccCheckHerokuBuildConfig_basic(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_build" "foobar" {
@@ -270,13 +283,16 @@ resource "heroku_build" "foobar" {
     source {
         url = "https://github.com/heroku/terraform-provider-heroku/raw/update-heroku-api-client/heroku/test-fixtures/app.tgz"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuBuildConfig_fails(appName string) string {
+func testAccCheckHerokuBuildConfig_fails(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_build" "foobar" {
@@ -284,13 +300,16 @@ resource "heroku_build" "foobar" {
     source {
         url = "https://github.com/heroku/terraform-provider-heroku/raw/update-heroku-api-client/heroku/test-fixtures/app-broken-build.tgz"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuBuildConfig_insecureUrl(appName string) string {
+func testAccCheckHerokuBuildConfig_insecureUrl(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_build" "foobar" {
@@ -298,13 +317,16 @@ resource "heroku_build" "foobar" {
     source {
       url = "http://github.com/mars/terraform-provider-heroku/raw/update-heroku-api-client/heroku/test-fixtures/app.tgz"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuBuildConfig_noSource(appName string) string {
+func testAccCheckHerokuBuildConfig_noSource(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_build" "foobar" {
@@ -312,16 +334,19 @@ resource "heroku_build" "foobar" {
     source {
       version = "v0"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuBuildConfig_allOpts(appName string) string {
+func testAccCheckHerokuBuildConfig_allOpts(appName, org string) string {
 	// Manually generated `checksum` using `shasum --algorithm 256 app.tar.gz`
 	// per Heroku docs https://devcenter.heroku.com/articles/slug-checksums
 
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_build" "foobar" {
@@ -335,13 +360,16 @@ resource "heroku_build" "foobar" {
       url = "https://github.com/heroku/terraform-provider-heroku/raw/update-heroku-api-client/heroku/test-fixtures/app.tgz"
       version = "v0"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuBuildConfig_localSourceDirectory(appName string) string {
+func testAccCheckHerokuBuildConfig_localSourceDirectory(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_build" "foobar" {
@@ -349,26 +377,32 @@ resource "heroku_build" "foobar" {
     source {
       path = "test-fixtures/app/"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuBuildConfig_localSourceDirectorySelfContained(appName string) string {
+func testAccCheckHerokuBuildConfig_localSourceDirectorySelfContained(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
  resource "heroku_build" "foobar" {
     app_id = heroku_app.foobar.id
     source {
       path = "."
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuBuildConfig_localSourceTarball(appName string) string {
+func testAccCheckHerokuBuildConfig_localSourceTarball(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_build" "foobar" {
@@ -376,13 +410,16 @@ resource "heroku_build" "foobar" {
     source {
       path = "test-fixtures/app.tgz"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuBuildConfig_localSourceTarball_setChecksum(appName string) string {
+func testAccCheckHerokuBuildConfig_localSourceTarball_setChecksum(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_build" "foobar" {
@@ -391,13 +428,16 @@ resource "heroku_build" "foobar" {
       checksum = "SHA256:0000000000000000000000000000000000000000000000000000000000000000"
       path = "test-fixtures/app.tgz"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuBuildConfig_localSourceTarball_allOpts(appName string) string {
+func testAccCheckHerokuBuildConfig_localSourceTarball_allOpts(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_build" "foobar" {
@@ -407,7 +447,7 @@ resource "heroku_build" "foobar" {
       path = "test-fixtures/app.tgz"
       version = "v0"
     }
-}`, appName)
+}`, appName, org)
 }
 
 func testAccCheckCaptureSourceChecksum(buildName string, originalSourceChecksum *string) resource.TestCheckFunc {

--- a/heroku/resource_heroku_collaborator_test.go
+++ b/heroku/resource_heroku_collaborator_test.go
@@ -16,6 +16,7 @@ func TestAccHerokuCollaborator_Basic(t *testing.T) {
 
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	testUser := testAccConfig.GetNonAdminUserOrAbort(t)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -24,7 +25,7 @@ func TestAccHerokuCollaborator_Basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuCollaborator_Basic(appName, testUser),
+				Config: testAccCheckHerokuCollaborator_Basic(appName, testUser, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuCollaboratorExists("heroku_collaborator.foobar-collaborator", &collaborator),
 					testAccCheckHerokuCollaboratorEmailAttribute(&collaborator, testUser),
@@ -75,15 +76,18 @@ func testAccCheckHerokuCollaboratorEmailAttribute(collaborator *heroku.Collabora
 	}
 }
 
-func testAccCheckHerokuCollaborator_Basic(appName, testUser string) string {
+func testAccCheckHerokuCollaborator_Basic(appName, testUser, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 resource "heroku_collaborator" "foobar-collaborator" {
 	app_id = heroku_app.foobar.id
 	email = "%s"
 }
-`, appName, testUser)
+`, appName, org, testUser)
 }

--- a/heroku/resource_heroku_domain_test.go
+++ b/heroku/resource_heroku_domain_test.go
@@ -19,6 +19,7 @@ func TestAccHerokuDomain_Basic(t *testing.T) {
 	var endpoint heroku.SniEndpoint
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -26,7 +27,7 @@ func TestAccHerokuDomain_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDomainConfig_basic(appName),
+				Config: testAccCheckHerokuDomainConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDomainExists("heroku_domain.one", &domain),
 					testAccCheckHerokuDomainAttributes(&domain, &endpoint),
@@ -43,6 +44,7 @@ func TestAccHerokuDomain_ACM(t *testing.T) {
 	var endpoint heroku.SniEndpoint
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,7 +52,7 @@ func TestAccHerokuDomain_ACM(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDomainConfig_ACM(appName),
+				Config: testAccCheckHerokuDomainConfig_ACM(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDomainExists("heroku_domain.one", &domain),
 					testAccCheckHerokuDomainAttributes(&domain, &endpoint),
@@ -68,6 +70,7 @@ func TestAccHerokuDomain_No_SSL_Change(t *testing.T) {
 	var endpoint heroku.SniEndpoint
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -75,7 +78,7 @@ func TestAccHerokuDomain_No_SSL_Change(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDomainConfig_ssl_no_association(appName),
+				Config: testAccCheckHerokuDomainConfig_ssl_no_association(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDomainExists("heroku_domain.one", &domain),
 					testAccCheckHerokuSSLExists("heroku_ssl.one", &endpoint),
@@ -87,7 +90,7 @@ func TestAccHerokuDomain_No_SSL_Change(t *testing.T) {
 			},
 			{
 				PreConfig: test.Sleep(t, 15),
-				Config:    testAccCheckHerokuDomainConfig_ssl(appName),
+				Config:    testAccCheckHerokuDomainConfig_ssl(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDomainExists("heroku_domain.one", &domain),
 					testAccCheckHerokuSSLExists("heroku_ssl.one", &endpoint),
@@ -106,6 +109,7 @@ func TestAccHerokuDomain_SSL(t *testing.T) {
 	var endpoint heroku.SniEndpoint
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,7 +117,7 @@ func TestAccHerokuDomain_SSL(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDomainConfig_ssl(appName),
+				Config: testAccCheckHerokuDomainConfig_ssl(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDomainExists("heroku_domain.one", &domain),
 					testAccCheckHerokuSSLExists("heroku_ssl.one", &endpoint),
@@ -125,7 +129,7 @@ func TestAccHerokuDomain_SSL(t *testing.T) {
 			},
 			{
 				PreConfig: test.Sleep(t, 15),
-				Config:    testAccCheckHerokuDomainConfig_ssl_change(appName),
+				Config:    testAccCheckHerokuDomainConfig_ssl_change(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDomainExists("heroku_domain.one", &domain),
 					testAccCheckHerokuSSLExists("heroku_ssl.two", &endpoint),
@@ -207,7 +211,7 @@ func testAccCheckHerokuDomainExists(n string, Domain *heroku.Domain) resource.Te
 	}
 }
 
-func testAccCheckHerokuDomainConfig_ssl_no_association(appName string) string {
+func testAccCheckHerokuDomainConfig_ssl_no_association(appName, org string) string {
 	wd, _ := os.Getwd()
 	certFile := wd + "/test-fixtures/terraform.cert"
 	keyFile := wd + "/test-fixtures/terraform.key"
@@ -215,6 +219,9 @@ func testAccCheckHerokuDomainConfig_ssl_no_association(appName string) string {
 	return fmt.Sprintf(`resource "heroku_app" "one" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "one" {
@@ -252,10 +259,10 @@ resource "heroku_domain" "one" {
   hostname = "terraform-%s.example.com"
   # Wait until the certificate has been created before adding domains to avoid auto-association. Once auto-association has been sunset we no longer need to do this. See https://devcenter.heroku.com/changelog-items/1938.
   depends_on = [heroku_ssl.one]
-}`, appName, certFile, keyFile, appName)
+}`, appName, org, certFile, keyFile, appName)
 }
 
-func testAccCheckHerokuDomainConfig_ssl_change(appName string) string {
+func testAccCheckHerokuDomainConfig_ssl_change(appName, org string) string {
 	wd, _ := os.Getwd()
 	certFile := wd + "/test-fixtures/terraform.cert"
 	keyFile := wd + "/test-fixtures/terraform.key"
@@ -263,6 +270,9 @@ func testAccCheckHerokuDomainConfig_ssl_change(appName string) string {
 	return fmt.Sprintf(`resource "heroku_app" "one" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "one" {
@@ -304,10 +314,10 @@ resource "heroku_domain" "one" {
   app_id = heroku_app.one.id
   hostname = "terraform-%s.example.com"
   sni_endpoint_id = "${heroku_ssl.two.id}"
-}`, appName, certFile, keyFile, certFile, keyFile, appName)
+}`, appName, org, certFile, keyFile, certFile, keyFile, appName)
 }
 
-func testAccCheckHerokuDomainConfig_ssl(appName string) string {
+func testAccCheckHerokuDomainConfig_ssl(appName, org string) string {
 	wd, _ := os.Getwd()
 	certFile := wd + "/test-fixtures/terraform.cert"
 	keyFile := wd + "/test-fixtures/terraform.key"
@@ -315,6 +325,9 @@ func testAccCheckHerokuDomainConfig_ssl(appName string) string {
 	return fmt.Sprintf(`resource "heroku_app" "one" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "one" {
@@ -349,30 +362,36 @@ resource "heroku_domain" "one" {
   app_id = heroku_app.one.id
   hostname = "terraform-%s.example.com"
   sni_endpoint_id = "${heroku_ssl.one.id}"
-}`, appName, certFile, keyFile, appName)
+}`, appName, org, certFile, keyFile, appName)
 }
 
-func testAccCheckHerokuDomainConfig_basic(appName string) string {
+func testAccCheckHerokuDomainConfig_basic(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "one" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_domain" "one" {
   app_id = heroku_app.one.id
   hostname = "terraform-%s.example.com"
-}`, appName, appName)
+}`, appName, org, appName)
 }
 
-func testAccCheckHerokuDomainConfig_ACM(appName string) string {
+func testAccCheckHerokuDomainConfig_ACM(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "one" {
     name = "%s"
     region = "us"
     acm = true
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_domain" "one" {
   app_id = heroku_app.one.id
   hostname = "terraform-%s.example.com"
-}`, appName, appName)
+}`, appName, org, appName)
 }

--- a/heroku/resource_heroku_drain_test.go
+++ b/heroku/resource_heroku_drain_test.go
@@ -14,6 +14,7 @@ import (
 func TestAccHerokuDrain_Basic(t *testing.T) {
 	var drain heroku.LogDrain
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,7 +22,7 @@ func TestAccHerokuDrain_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDrainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDrainConfig_basic(appName),
+				Config: testAccCheckHerokuDrainConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDrainExists("heroku_drain.foobar", &drain),
 					testAccCheckHerokuDrainAttributes(&drain),
@@ -38,6 +39,7 @@ func TestAccHerokuDrain_Basic(t *testing.T) {
 func TestAccHerokuDrain_BasicWithSensitiveURL(t *testing.T) {
 	var drain heroku.LogDrain
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -45,7 +47,7 @@ func TestAccHerokuDrain_BasicWithSensitiveURL(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuDrainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuDrainConfig_basicWithSensitiveURL(appName),
+				Config: testAccCheckHerokuDrainConfig_basicWithSensitiveURL(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDrainExists("heroku_drain.foobar", &drain),
 					testAccCheckHerokuDrainAttributes(&drain),
@@ -122,28 +124,34 @@ func testAccCheckHerokuDrainExists(n string, Drain *heroku.LogDrain) resource.Te
 	}
 }
 
-func testAccCheckHerokuDrainConfig_basic(appName string) string {
+func testAccCheckHerokuDrainConfig_basic(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_drain" "foobar" {
     app_id = heroku_app.foobar.id
     url = "syslog://terraform.example.com:1234"
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuDrainConfig_basicWithSensitiveURL(appName string) string {
+func testAccCheckHerokuDrainConfig_basicWithSensitiveURL(appName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_drain" "foobar" {
     app_id = heroku_app.foobar.id
     sensitive_url = "syslog://terraform.example.com:1234"
-}`, appName)
+}`, appName, org)
 }

--- a/heroku/resource_heroku_formation_test.go
+++ b/heroku/resource_heroku_formation_test.go
@@ -127,6 +127,7 @@ resource "heroku_formation" "foobar-web" {
 	type = "web"
 	size = "%s"
 	quantity = %d
+	depends_on = [heroku_app_release.foobar-release]
 }
 `, appName, org, slugId, dynoSize, dynoQuant)
 }
@@ -149,6 +150,7 @@ resource "heroku_formation" "foobar-web" {
 	type = "web"
 	size = "%s"
 	quantity = %d
+	depends_on = [heroku_app_release.foobar-release]
 }
 `, appName, org, slugId, dynoSize, dynoQuant)
 }

--- a/heroku/resource_heroku_formation_test.go
+++ b/heroku/resource_heroku_formation_test.go
@@ -43,6 +43,7 @@ func TestAccHerokuFormationUpdateFreeDyno(t *testing.T) {
 	var formation heroku.Formation
 
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 	slugID := testAccConfig.GetSlugIDOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
@@ -52,7 +53,7 @@ func TestAccHerokuFormationUpdateFreeDyno(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuFormationConfig_WithOutOrg(appName, slugID, "basic", 1),
+				Config: testAccCheckHerokuFormationConfig_WithOutOrg(appName, org, slugID, "basic", 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuFormationExists("heroku_formation.foobar-web", &formation),
 					testAccCheckHerokuFormationSizeAttribute(&formation, "Basic"),
@@ -130,11 +131,14 @@ resource "heroku_formation" "foobar-web" {
 `, appName, org, slugId, dynoSize, dynoQuant)
 }
 
-func testAccCheckHerokuFormationConfig_WithOutOrg(appName, slugId, dynoSize string, dynoQuant int) string {
+func testAccCheckHerokuFormationConfig_WithOutOrg(appName, org, slugId, dynoSize string, dynoQuant int) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 resource "heroku_app_release" "foobar-release" {
 	app_id = heroku_app.foobar.id
@@ -146,5 +150,5 @@ resource "heroku_formation" "foobar-web" {
 	size = "%s"
 	quantity = %d
 }
-`, appName, slugId, dynoSize, dynoQuant)
+`, appName, org, slugId, dynoSize, dynoQuant)
 }

--- a/heroku/resource_heroku_pipeline_coupling_test.go
+++ b/heroku/resource_heroku_pipeline_coupling_test.go
@@ -41,6 +41,10 @@ func TestAccHerokuPipelineCoupling_Basic(t *testing.T) {
 
 func testAccCheckHerokuPipelineCouplingConfig_basic(appName, pipelineName, stageName, org string) string {
 	return fmt.Sprintf(`
+data "heroku_team" "default" {
+  name = "%s"
+}
+
 resource "heroku_app" "default" {
   name   = "%s"
   region = "us"
@@ -51,6 +55,10 @@ resource "heroku_app" "default" {
 
 resource "heroku_pipeline" "default" {
   name = "%s"
+  owner {
+    id   = data.heroku_team.default.id
+    type = "team"
+  }
 }
 
 resource "heroku_pipeline_coupling" "default" {
@@ -58,7 +66,7 @@ resource "heroku_pipeline_coupling" "default" {
   pipeline = heroku_pipeline.default.id
   stage    = "%s"
 }
-`, appName, org, pipelineName, stageName)
+`, org, appName, org, pipelineName, stageName)
 }
 
 func testAccCheckHerokuPipelineCouplingExists(n string, pipeline *heroku.PipelineCoupling) resource.TestCheckFunc {

--- a/heroku/resource_heroku_pipeline_coupling_test.go
+++ b/heroku/resource_heroku_pipeline_coupling_test.go
@@ -17,6 +17,7 @@ func TestAccHerokuPipelineCoupling_Basic(t *testing.T) {
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	pipelineName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	stageName := "development"
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,7 +25,7 @@ func TestAccHerokuPipelineCoupling_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuPipelineCouplingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuPipelineCouplingConfig_basic(appName, pipelineName, stageName),
+				Config: testAccCheckHerokuPipelineCouplingConfig_basic(appName, pipelineName, stageName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuPipelineCouplingExists("heroku_pipeline_coupling.default", &coupling),
 					testAccCheckHerokuPipelineCouplingAttributes(
@@ -38,11 +39,14 @@ func TestAccHerokuPipelineCoupling_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckHerokuPipelineCouplingConfig_basic(appName, pipelineName, stageName string) string {
+func testAccCheckHerokuPipelineCouplingConfig_basic(appName, pipelineName, stageName, org string) string {
 	return fmt.Sprintf(`
 resource "heroku_app" "default" {
   name   = "%s"
   region = "us"
+  organization {
+    name = "%s"
+  }
 }
 
 resource "heroku_pipeline" "default" {
@@ -54,7 +58,7 @@ resource "heroku_pipeline_coupling" "default" {
   pipeline = heroku_pipeline.default.id
   stage    = "%s"
 }
-`, appName, pipelineName, stageName)
+`, appName, org, pipelineName, stageName)
 }
 
 func testAccCheckHerokuPipelineCouplingExists(n string, pipeline *heroku.PipelineCoupling) resource.TestCheckFunc {

--- a/heroku/resource_heroku_slug_test.go
+++ b/heroku/resource_heroku_slug_test.go
@@ -17,13 +17,14 @@ func TestAccHerokuSlug_Basic(t *testing.T) {
 	var slug heroku.Slug
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSlugConfig_basic(appName),
+				Config: testAccCheckHerokuSlugConfig_basic(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSlugExists("heroku_slug.foobar", &slug),
 				),
@@ -35,13 +36,14 @@ func TestAccHerokuSlug_Basic(t *testing.T) {
 func TestAccHerokuSlug_NoFile(t *testing.T) {
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckHerokuSlugConfig_noFile(appName),
+				Config:      testAccCheckHerokuSlugConfig_noFile(appName, org),
 				ExpectError: regexp.MustCompile(`requires either`),
 			},
 		},
@@ -52,13 +54,14 @@ func TestAccHerokuSlug_AllOpts(t *testing.T) {
 	var slug heroku.Slug
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSlugConfig_allOpts(appName),
+				Config: testAccCheckHerokuSlugConfig_allOpts(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSlugExists("heroku_slug.foobar", &slug),
 				),
@@ -71,6 +74,7 @@ func TestAccHerokuSlug_WithFile(t *testing.T) {
 	var slug, slug2 heroku.Slug
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 	// Manually generated using `shasum --algorithm 256 slug.tgz`
 	// per Heroku docs https://devcenter.heroku.com/articles/slug-checksums
 	slugChecksum := "SHA256:6731cb5caea2cda97c6177216373360a0733aa8e7a21801de879fa8d22f740cf"
@@ -83,7 +87,7 @@ func TestAccHerokuSlug_WithFile(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSlugConfig_withFile(appName),
+				Config: testAccCheckHerokuSlugConfig_withFile(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSlugExists("heroku_slug.foobar", &slug),
 					resource.TestCheckResourceAttr("heroku_slug.foobar", "checksum", slugChecksum),
@@ -91,7 +95,7 @@ func TestAccHerokuSlug_WithFile(t *testing.T) {
 			},
 			{
 				SkipFunc: switchSlugFiles,
-				Config:   testAccCheckHerokuSlugConfig_withFile(appName),
+				Config:   testAccCheckHerokuSlugConfig_withFile(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSlugExists("heroku_slug.foobar", &slug2),
 					resource.TestCheckResourceAttr("heroku_slug.foobar", "checksum", slugChecksum2),
@@ -105,6 +109,7 @@ func TestAccHerokuSlug_WithRemoteFile(t *testing.T) {
 	var slug heroku.Slug
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 	// Manually generated using `shasum --algorithm 256 slug.tgz`
 	// per Heroku docs https://devcenter.heroku.com/articles/slug-checksums
 	slugChecksum := "SHA256:6731cb5caea2cda97c6177216373360a0733aa8e7a21801de879fa8d22f740cf"
@@ -114,7 +119,7 @@ func TestAccHerokuSlug_WithRemoteFile(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSlugConfig_withRemoteFile(appName),
+				Config: testAccCheckHerokuSlugConfig_withRemoteFile(appName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSlugExists("heroku_slug.foobar", &slug),
 					resource.TestCheckResourceAttr("heroku_slug.foobar", "checksum", slugChecksum),
@@ -127,13 +132,14 @@ func TestAccHerokuSlug_WithRemoteFile(t *testing.T) {
 func TestAccHerokuSlug_WithInsecureRemoteFile(t *testing.T) {
 	randString := acctest.RandString(10)
 	appName := fmt.Sprintf("tftest-%s", randString)
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckHerokuSlugConfig_withInsecureRemoteFile(appName),
+				Config:      testAccCheckHerokuSlugConfig_withInsecureRemoteFile(appName, org),
 				ExpectError: regexp.MustCompile(`must be a secure URL`),
 			},
 		},
@@ -190,10 +196,13 @@ func testAccCheckHerokuSlugExists(n string, Slug *heroku.Slug) resource.TestChec
 	}
 }
 
-func testAccCheckHerokuSlugConfig_basic(appName string) string {
+func testAccCheckHerokuSlugConfig_basic(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "foobar" {
@@ -203,13 +212,16 @@ resource "heroku_slug" "foobar" {
     	test = "echo 'Just a test'"
     	diag = "echo 'Just diagnosis'"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuSlugConfig_noFile(appName string) string {
+func testAccCheckHerokuSlugConfig_noFile(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "foobar" {
@@ -218,13 +230,16 @@ resource "heroku_slug" "foobar" {
       test = "echo 'Just a test'"
       diag = "echo 'Just diagnosis'"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuSlugConfig_allOpts(appName string) string {
+func testAccCheckHerokuSlugConfig_allOpts(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "foobar" {
@@ -237,13 +252,16 @@ resource "heroku_slug" "foobar" {
     	test = "echo 'Just a test'"
     	diag = "echo 'Just diagnosis'"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuSlugConfig_withFile(appName string) string {
+func testAccCheckHerokuSlugConfig_withFile(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "foobar" {
@@ -253,13 +271,16 @@ resource "heroku_slug" "foobar" {
     process_types = {
       web = "ruby server.rb"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuSlugConfig_withRemoteFile(appName string) string {
+func testAccCheckHerokuSlugConfig_withRemoteFile(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "foobar" {
@@ -269,13 +290,16 @@ resource "heroku_slug" "foobar" {
     process_types = {
       web = "ruby server.rb"
     }
-}`, appName)
+}`, appName, org)
 }
 
-func testAccCheckHerokuSlugConfig_withInsecureRemoteFile(appName string) string {
+func testAccCheckHerokuSlugConfig_withInsecureRemoteFile(appName, org string) string {
 	return fmt.Sprintf(`resource "heroku_app" "foobar" {
     name = "%s"
     region = "us"
+    organization {
+        name = "%s"
+    }
 }
 
 resource "heroku_slug" "foobar" {
@@ -285,7 +309,7 @@ resource "heroku_slug" "foobar" {
     process_types = {
       web = "ruby server.rb"
     }
-}`, appName)
+}`, appName, org)
 }
 
 func testAccCheckHerokuSlugConfig_withFile_inPrivateSpace(spaceConfig, appName, orgName string) string {

--- a/heroku/resource_heroku_ssl_test.go
+++ b/heroku/resource_heroku_ssl_test.go
@@ -18,6 +18,7 @@ import (
 func TestAccHerokuSSL_basic(t *testing.T) {
 	var endpoint heroku.SniEndpoint
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := testAccConfig.GetOrganizationOrSkip(t)
 
 	wd, _ := os.Getwd()
 	certFile := wd + "/test-fixtures/terraform.cert"
@@ -36,7 +37,7 @@ func TestAccHerokuSSL_basic(t *testing.T) {
 		CheckDestroy: testAccCheckHerokuSSLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHerokuSSLConfig(appName, certFile2, keyFile2),
+				Config: testAccCheckHerokuSSLConfig(appName, org, certFile2, keyFile2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSSLExists("heroku_ssl.one", &endpoint),
 					testAccCheckHerokuSSLCertificateChain(&endpoint, certificateChain2),
@@ -46,7 +47,7 @@ func TestAccHerokuSSL_basic(t *testing.T) {
 			},
 			{
 				PreConfig: test.Sleep(t, 15),
-				Config:    testAccCheckHerokuSSLConfig(appName, certFile, keyFile),
+				Config:    testAccCheckHerokuSSLConfig(appName, org, certFile, keyFile),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSSLExists("heroku_ssl.one", &endpoint),
 					testAccCheckHerokuSSLCertificateChain(&endpoint, certificateChain),
@@ -58,11 +59,14 @@ func TestAccHerokuSSL_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckHerokuSSLConfig(appName, certFile, keyFile string) string {
+func testAccCheckHerokuSSLConfig(appName, org, certFile, keyFile string) string {
 	return strings.TrimSpace(fmt.Sprintf(`
 resource "heroku_app" "one" {
   name = "%s"
   region = "us"
+  organization {
+    name = "%s"
+  }
 }
 
 resource "heroku_slug" "one" {
@@ -91,7 +95,7 @@ resource "heroku_ssl" "one" {
   certificate_chain = file("%s")
   private_key = file("%s")
   depends_on = [heroku_formation.web]
-}`, appName, certFile, keyFile))
+}`, appName, org, certFile, keyFile))
 }
 
 func testAccCheckHerokuSSLDestroy(s *terraform.State) error {


### PR DESCRIPTION
## Summary

- Heroku API policy change (landed between June 24–July 13, 2026) disallows Salesforce internal users from creating personal apps — all apps must belong to a team/organization
- This caused every acceptance test that created a bare `heroku_app` without an org to fail with a 422 from the Heroku API
- Updated 30 test files across resource, import, and datasource tests to pass an organization block to every `heroku_app` resource

## Changes

- Added `org string` parameter to all config template functions that create a `heroku_app`
- Added `organization { name = "%s" }` block inside every affected `heroku_app` resource in test configs
- Added `org := testAccConfig.GetOrganizationOrSkip(t)` (or `GetAnyOrganizationOrSkip` where the existing pattern required it) to every `TestAcc*` function
- All 30 files compile cleanly (`go test -run "^$" ./heroku/...` passes)

## Test plan

- [ ] Verify `HEROKU_ORGANIZATION` env var is set in CI secrets
- [ ] Run acceptance tests: `TF_ACC=1 go test ./heroku/... -v -run TestAcc` against a Salesforce-internal Heroku account
- [ ] Confirm previously-failing tests (app, addon, build, domain, drain, slug, ssl, formation, pipeline coupling, collaborator, webhook, datasources) now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)