### PR TITLE
Omit sensitive_vars values from TF_LOG=debug output

### DIFF
--- a/heroku/resource_heroku_app_config_association.go
+++ b/heroku/resource_heroku_app_config_association.go
@@ -152,7 +152,11 @@ func resourceHerokuAppConfigAssociationDelete(d *schema.ResourceData, m interfac
 func updateVars(id string, client *heroku.Service, o map[string]interface{}, n map[string]interface{}) error {
 	vars := constructVars(o, n)
 
-	log.Printf("[INFO] Updating config vars: *%#v", vars)
+	var varKeys []string
+	for k := range vars {
+		varKeys = append(varKeys, k)
+	}
+	log.Printf("[INFO] Updating config vars (keys only): %s", varKeys)
 	if _, err := client.ConfigVarUpdate(context.TODO(), id, vars); err != nil {
 		return fmt.Errorf("error updating config vars: %s", err)
 	}
@@ -201,7 +205,11 @@ func getSensitiveVars(d *schema.ResourceData) map[string]interface{} {
 	var sensitiveVars map[string]interface{}
 	if v, ok := d.GetOk("sensitive_vars"); ok {
 		vs := v.(map[string]interface{})
-		log.Printf("[DEBUG] sensitive vars: %s", vs)
+		var keys []string
+		for k := range vs {
+			keys = append(keys, k)
+		}
+		log.Printf("[DEBUG] sensitive vars (keys only): %s", keys)
 		sensitiveVars = vs
 	}
 

--- a/heroku/resource_heroku_config.go
+++ b/heroku/resource_heroku_config.go
@@ -61,7 +61,11 @@ func resourceHerokuConfigCreate(d *schema.ResourceData, m interface{}) error {
 
 	if v, ok := d.GetOk("sensitive_vars"); ok {
 		vs := v.(map[string]interface{})
-		log.Printf("[DEBUG] sensitive vars: %v", vs)
+		var keys []string
+		for k := range vs {
+			keys = append(keys, k)
+		}
+		log.Printf("[DEBUG] sensitive vars (keys only): %s", keys)
 		sensitiveVars = vs
 	}
 
@@ -105,7 +109,11 @@ func resourceHerokuConfigUpdate(d *schema.ResourceData, m interface{}) error {
 	if d.HasChange("sensitive_vars") {
 		v := d.Get("sensitive_vars")
 		vs := v.(map[string]interface{})
-		log.Printf("[DEBUG] sensitive vars: %v", vs)
+		var keys []string
+		for k := range vs {
+			keys = append(keys, k)
+		}
+		log.Printf("[DEBUG] sensitive vars (keys only): %s", keys)
 		sensitiveVars = vs
 	}
 

--- a/heroku/resource_heroku_pipeline_config_var.go
+++ b/heroku/resource_heroku_pipeline_config_var.go
@@ -152,8 +152,12 @@ func resourceHerokuPipelineConfigVarRead(d *schema.ResourceData, meta interface{
 
 	vettedConfigVars, vettedSensitiveConfigVars := vetVarsForState(getVars(d), getSensitiveVars(d), rpvFormatted)
 
+	var sensitiveVarKeys []string
+	for k := range vettedSensitiveConfigVars {
+		sensitiveVarKeys = append(sensitiveVarKeys, k)
+	}
 	log.Printf("[DEBUG] pipeline config vars to be set in state: *%#v", vettedConfigVars)
-	log.Printf("[DEBUG] pipeline sensitive config vars to be set in state: *%#v", vettedSensitiveConfigVars)
+	log.Printf("[DEBUG] pipeline sensitive config vars to be set in state (keys only): %s", sensitiveVarKeys)
 
 	var setErr error
 	setErr = d.Set("pipeline_id", pipelineID)
@@ -191,13 +195,17 @@ func updatePipelineConfigVars(client *heroku.Service, pipelineID, pipelineStage 
 	oldVars, newVars map[string]interface{}) error {
 	varsToModify := constructVars(oldVars, newVars)
 
-	log.Printf("[INFO] Modifying pipeline [%s] stage [%s] config vars: *%#v", pipelineID, pipelineStage, varsToModify)
+	var varKeys []string
+	for k := range varsToModify {
+		varKeys = append(varKeys, k)
+	}
+	log.Printf("[INFO] Modifying pipeline [%s] stage [%s] config vars (keys only): %s", pipelineID, pipelineStage, varKeys)
 
 	if _, updateErr := client.PipelineConfigVarUpdate(context.TODO(), pipelineID, pipelineStage, varsToModify); updateErr != nil {
 		return fmt.Errorf("error updating pipeline config vars: %s", updateErr)
 	}
 
-	log.Printf("[INFO] Modifying pipeline [%s] stage [%s] config vars: *%#v", pipelineID, pipelineStage, varsToModify)
+	log.Printf("[INFO] Modified pipeline [%s] stage [%s] config vars (keys only): %s", pipelineID, pipelineStage, varKeys)
 
 	return nil
 }


### PR DESCRIPTION
Extends the fix from #362 to the three resources it did not cover.

`heroku_config`, `heroku_app_config_association`, and `heroku_pipeline_config_var` were logging the full contents of `sensitive_vars` maps when running with `TF_LOG=debug`, disclosing variable values in plaintext. This changes those log statements to output only the variable names, consistent with the behavior introduced in #362 for `heroku_app`.

## Changes

- `heroku_config` — `resourceHerokuConfigCreate` and `resourceHerokuConfigUpdate` no longer log sensitive var values
- `heroku_app_config_association` — `getSensitiveVars` and `updateVars` no longer log sensitive var values
- `heroku_pipeline_config_var` — `resourceHerokuPipelineConfigVarRead` and `updatePipelineConfigVars` no longer log sensitive var values